### PR TITLE
Fix: Actually use the newly introduced http.client

### DIFF
--- a/haproxy_exporter.go
+++ b/haproxy_exporter.go
@@ -229,7 +229,7 @@ func (e *Exporter) scrape(csvRows chan<- []string) {
 
 	e.totalScrapes.Inc()
 
-	resp, err := http.Get(e.URI)
+	resp, err := e.client.Get(e.URI)
 	if err != nil {
 		e.up.Set(0)
 		log.Printf("Error while scraping HAProxy: %v", err)


### PR DESCRIPTION
I introduced the http client with timeout but missed to use it for the actual GET m(. Here is the fix.
