### PR TITLE
Extract common Makefile parts into Makefile.COMMON.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
-.deps
+.build
 bin/haproxy_exporter*
 haproxy_exporter
 *.tar.gz
 *.test
 *.mprof
+*-stamp

--- a/Makefile
+++ b/Makefile
@@ -1,74 +1,17 @@
-VERSION    := 0.4.0
-GO_VERSION ?= 1.4
+# Copyright 2015 The Prometheus Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-SRC      := $(wildcard *.go)
-TARGET   := haproxy_exporter
+VERSION := 0.4.0
+TARGET  := haproxy_exporter
 
-OS   := $(subst Darwin,darwin,$(subst Linux,linux,$(subst FreeBSD,freebsd,$(shell uname))))
-ARCH := $(subst x86_64,amd64,$(patsubst i%86,386,$(shell uname -m)))
-
-ifeq ($(GOOS),darwin)
-RELEASE_SUFFIX ?= -osx$(MAC_OS_X_VERSION)
-else
-RELEASE_SUFFIX ?=
-endif
-
-GOOS   ?= $(OS)
-GOARCH ?= $(ARCH)
-GOPKG  := go$(GO_VERSION).$(GOOS)-$(GOARCH)$(RELEASE_SUFFIX).tar.gz
-GOURL	 := https://golang.org/dl
-GOROOT ?= $(CURDIR)/.deps/go
-GOPATH ?= $(CURDIR)/.deps/gopath
-GOCC   := $(GOROOT)/bin/go
-GOLIB  := $(GOROOT)/pkg/$(GOOS)_$(GOARCH)
-GO     := GOROOT=$(GOROOT) GOPATH=$(GOPATH) $(GOCC)
-
-SUFFIX  := $(GOOS)-$(GOARCH)
-BINARY  := bin/$(TARGET)
-ARCHIVE := $(TARGET)-$(VERSION).$(SUFFIX).tar.gz
-
-default: build
-
-build: $(BINARY)
-
-.deps/$(GOPKG):
-	mkdir -p .deps
-	curl -o $@ -L $(GOURL)/$(GOPKG)
-
-$(GOCC): .deps/$(GOPKG)
-	tar -C .deps -xzf .deps/$(GOPKG)
-	touch $@
-
-$(GOLIB):
-	cd .deps/go/src && CGO_ENABLED=0 ./make.bash
-
-dependencies: $(SRC)
-	$(GO) get -d
-
-$(BINARY): $(GOCC) $(GOLIB) $(SRC) dependencies
-	$(GO) build -o $@
-
-$(ARCHIVE): $(BINARY)
-	tar -czf $@ bin/
-
-upload: REMOTE     ?= $(error "can't upload, REMOTE not set")
-upload: REMOTE_DIR ?= $(error "can't upload, REMOTE_DIR not set")
-upload: $(ARCHIVE)
-	scp $(ARCHIVE) $(REMOTE):$(REMOTE_DIR)/$(ARCHIVE)
-
-release: REMOTE     ?= $(error "can't release, REMOTE not set")
-release: REMOTE_DIR ?= $(error "can't release, REMOTE_DIR not set")
-release:
-	GOOS=linux  REMOTE=$(REMOTE) REMOTE_DIR=$(REMOTE_DIR) $(MAKE) upload
-	GOOS=darwin REMOTE=$(REMOTE) REMOTE_DIR=$(REMOTE_DIR) $(MAKE) upload
-
-test:
-	go test ./...
-
-benchmark:
-	go test -bench . -test.benchmem -benchtime=10s
-
-clean:
-	rm -rf bin
-
-.PHONY: test tag dependencies clean release upload
+include Makefile.COMMON

--- a/Makefile.COMMON
+++ b/Makefile.COMMON
@@ -1,0 +1,103 @@
+# Copyright 2015 The Prometheus Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file provides common Makefile infrastructure for several Prometheus
+# components. This includes make tasks for downloading Go, setting up a
+# self-contained build environment, fetching Go dependencies, building
+# binaries, running tests, and doing release management. This file is intended
+# to be included from a project's Makefile, which needs to define the following
+# variables, at a minimum:
+#
+# * VERSION - The current version of the project in question.
+# * TARGET  - The desired name of the built binary.
+#
+# Many of the variables defined below are defined conditionally (using '?'),
+# which allows the project's main Makefile to override any of these settings, if
+# needed. See also:
+#
+# https://www.gnu.org/software/make/manual/html_node/Flavors.html#Flavors.
+#
+# The including Makefile may define any number of extra targets that are
+# specific to that project.
+
+VERSION ?= $(error VERSION not set in including Makefile)
+TARGET  ?= $(error TARGET not set in including Makefile)
+
+SRC    ?= $(shell find . -type f -name "*.go" ! -path "./.build/*")
+GOOS   := $(shell uname | tr A-Z a-z)
+GOARCH := $(subst x86_64,amd64,$(patsubst i%86,386,$(shell uname -m)))
+
+ifeq ($(GOOS),darwin)
+	RELEASE_SUFFIX ?= -osx$(shell sw_vers -productVersion)
+endif
+
+GO_VERSION ?= 1.4.1
+GOURL      ?= https://golang.org/dl
+GOPKG      ?= go$(GO_VERSION).$(GOOS)-$(GOARCH)$(RELEASE_SUFFIX).tar.gz
+GOROOT     := $(CURDIR)/.build/go
+GOPATH     := $(CURDIR)/.build/gopath
+GOCC       ?= $(GOROOT)/bin/go
+GO         ?= GOROOT=$(GOROOT) GOPATH=$(GOPATH) $(GOCC)
+GOFMT      ?= $(GOROOT)/bin/gofmt
+
+# Never honor GOBIN, should it be set at all.
+unexport GOBIN
+
+SUFFIX   ?= $(GOOS)-$(GOARCH)
+BINARY   ?= $(TARGET)
+ARCHIVE  ?= $(TARGET)-$(VERSION).$(SUFFIX).tar.gz
+ROOTPKG  ?= github.com/prometheus/$(TARGET)
+SELFLINK ?= $(GOPATH)/src/$(ROOTPKG)
+
+default: $(BINARY)
+
+.build/$(GOPKG):
+	mkdir -p $(GOROOT)
+	mkdir -p $(GOPATH)
+	curl -o .build/$(GOPKG) -L $(GOURL)/$(GOPKG)
+
+$(GOCC): .build/$(GOPKG)
+	tar -C .build -xzf .build/$(GOPKG)
+	touch $@
+
+selflink-stamp:
+	mkdir -p $(GOPATH)/src/github.com/prometheus
+	ln -s $(CURDIR) $(SELFLINK)
+	touch $@
+
+dependencies-stamp: $(SRC) selflink-stamp
+	$(GO) get -d
+	touch $@
+
+$(BINARY): $(GOCC) $(SRC) dependencies-stamp Makefile Makefile.COMMON
+	$(GO) build $(GOFLAGS) -o $@
+
+$(ARCHIVE): $(BINARY)
+	tar -czf $@ $<
+
+.PHONY: tag
+tag:
+	git tag $(VERSION)
+	git push --tags
+
+.PHONY: test
+test: $(GOCC) dependencies-stamp
+	$(GO) test ./...
+
+.PHONY: format
+format:
+	find . -iname '*.go' | egrep -v "^\./\.build|./generated|\./Godeps|\.(l|y)\.go" | xargs -n1 $(GOFMT) -w -s=true
+
+.PHONY: clean
+clean:
+	rm -rf $(BINARY) $(ARCHIVE) .build *-stamp


### PR DESCRIPTION
This is a test-drive for separating all common build functionality into
a separate Makefile.COMMON, which is included from an individual
project's Makefile (mainly for the various exporters, which should have
almost identical Makefiles, modulo accrued inconsistencies).

The main Makefile then only needs to define the VERSION and TARGET
variables and the Makefile.COMMON defines all the common targets. While
doing this, I decided per variable which one should be simply expanded
(`:=`) vs. conditionally set (`?=`). The former allows evaluating values
only once and on the spot (good for potentially costly evaluations),
while the latter allows overriding variables from the parent Makefile.
Unfortunately it's not possible to combine the two variants (like
`?:=`), so I had to chose which one seemed more important for each var
(being able to override it or only evaluating it once).

There's the question about how the Makefile.COMMON should be maintained
and how it should make its way into the various *_exporter (etc.) repos
in the future, and how it should be kept up-to-date. The authoritative
version of this file should probably live in its own ("build_common"?)
repo. It would of course be nice to download it dynamically from a
project's specific Makefile itself, but that would mean that all the
targets that Makefile.COMMON defines would only become available once
it's actually downloaded, so this would always require two make steps,
which doesn't seem like a good option. Another option could be to simply
manually copy it into every repository when there are upstream changes
to the common file. Opinions/ideas around this are appreciated.

One thing I generally improved in this new Makefile is that targets
like $(BINARY) are really only built if needed - that is, if one of the
source files actually changed. This is solved by creating a
"dependencies-stamp" file so we don't always repeat downloading
dependencies and "go build" every time you call "make", even if
the code didn't change. Granted, remote dependencies could have changed
upstream between make runs, but for those to take effect, I think it's
fair to require a "make clean" or deleting the "dependencies-stamp"
file.

I also simplified and automated the code around choosing the correct Mac
OS X Go release version, but wasn't able to test it. If anyone with OS X
could test it, that would be great.

Also, PHONY targets are now declared as such inline, making it more
obvious which target is PHONY, and easier to maintain PHONY-ness in
general.