### PR TITLE
ereq (requests errors) is a frontend metric

### DIFF
--- a/haproxy_exporter.go
+++ b/haproxy_exporter.go
@@ -147,7 +147,7 @@ func NewExporter(uri string, haProxyServerMetricFields string, timeout time.Dura
 			8:  newFrontendMetric("bytes_in_total", "Current total of incoming bytes.", nil),
 			9:  newFrontendMetric("bytes_out_total", "Current total of outgoing bytes.", nil),
 			10: newFrontendMetric("requests_denied_total", "Total of requests denied for security.", nil),
-			12: newBackendMetric("request_errors_total", "Total of request errors.", nil),
+			12: newFrontendMetric("request_errors_total", "Total of request errors.", nil),
 			33: newFrontendMetric("current_session_rate", "Current number of sessions per second over last elapsed second.", nil),
 			35: newFrontendMetric("max_session_rate", "Maximum number of sessions per second.", nil),
 			39: newFrontendMetric("http_responses_total", "Total of HTTP responses.", prometheus.Labels{"code": "1xx"}),


### PR DESCRIPTION
The requests error (ereq, 12th field) in [CSV format][1] is a metric only
available in frontend and listen objects.

 [1]: https://cbonte.github.io/haproxy-dconv/configuration-1.5.html#9.1