### PR TITLE
New Dockerfile using alpine-golang-make-onbuild base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,4 @@
-FROM       ubuntu:latest
-MAINTAINER Prometheus Team <prometheus-developers@googlegroups.com>
-ENTRYPOINT [ "./haproxy_exporter" ]
-EXPOSE     9101
+FROM        sdurrheimer/alpine-golang-make-onbuild
+MAINTAINER  The Prometheus Authors <prometheus-developers@googlegroups.com>
 
-RUN        apt-get -qy update && apt-get install -yq make git curl mercurial gcc
-ADD        . /haproxy_exporter
-WORKDIR    /haproxy_exporter
-RUN        make
+EXPOSE      9101

--- a/Makefile.COMMON
+++ b/Makefile.COMMON
@@ -49,19 +49,22 @@ ifeq ($(GOOS),darwin)
 endif
 
 GO_VERSION ?= 1.4.2
-
-ifeq ($(shell type go >/dev/null && go version | sed 's/.*go\([0-9.]*\).*/\1/'), $(GO_VERSION))
-	GOROOT := $(shell go env GOROOT)
-else
-	GOROOT := $(CURDIR)/.build/go$(GO_VERSION)
-endif
-
 GOURL      ?= https://golang.org/dl
 GOPKG      ?= go$(GO_VERSION).$(GOOS)-$(GOARCH)$(RELEASE_SUFFIX).tar.gz
 GOPATH     := $(CURDIR)/.build/gopath
-GOCC       ?= $(GOROOT)/bin/go
-GO         ?= GOROOT=$(GOROOT) GOPATH=$(GOPATH) $(GOCC)
-GOFMT      ?= $(GOROOT)/bin/gofmt
+
+# Check for the correct version of go in the path. If we find it, use it.
+# Otherwise, prepare to build go locally.
+ifeq ($(shell command -v "go" >/dev/null && go version | sed -e 's/^[^0-9.]*\([0-9.]*\).*/\1/'), $(GO_VERSION))
+	GOCC   ?= $(shell command -v "go")
+	GOFMT  ?= $(shell command -v "gofmt")
+	GO     ?= GOPATH=$(GOPATH) $(GOCC)
+else
+	GOROOT ?= $(CURDIR)/.build/go$(GO_VERSION)
+	GOCC   ?= $(GOROOT)/bin/go
+	GOFMT  ?= $(GOROOT)/bin/gofmt
+	GO     ?= GOROOT=$(GOROOT) GOPATH=$(GOPATH) $(GOCC)
+endif
 
 # Never honor GOBIN, should it be set at all.
 unexport GOBIN


### PR DESCRIPTION
Following the docker related PR series.

New Dockerfile using the [alpine-golang-make-onbuild](https://github.com/sdurrheimer/alpine-golang-make-onbuild) base image whose goal is to unified the way to dockerize prometheus tools and exporters based on Golang.

The binary is build using make. (Golang is installed via make too, respecting the GO_VERSION).

A testable image is available under my name on Docker hub : [Link](https://registry.hub.docker.com/u/sdurrheimer/haproxy-exporter/)

As always, the [alpine-golang-make-onbuild](https://github.com/sdurrheimer/alpine-golang-make-onbuild)  image can be also move under Prometheus organization.

@juliusv @discordianfish 