### PR TITLE
Handle invalid CSV lines gracefully

### DIFF
--- a/haproxy_exporter.go
+++ b/haproxy_exporter.go
@@ -267,7 +267,7 @@ func (e *Exporter) scrape(csvRows chan<- []string) {
 		if err != nil {
 			log.Errorf("Can't read CSV: %v", err)
 			e.csvParseFailures.Inc()
-			break
+			continue
 		}
 		if len(row) == 0 {
 			continue


### PR DESCRIPTION
Haproxy versions <1.6.4 respond with invalid CSV lines when a server
got drained via an agent[0]. This caused the haproxy_exporter to stop
reporting any metrics for following metrics.

[0]: http://permalink.gmane.org/gmane.comp.web.haproxy/27011

Fixes #45.

@matthiasr @bitfehler