### PR TITLE
Added support for haproxy scraping that implements basic auth

### DIFF
--- a/Makefile.COMMON
+++ b/Makefile.COMMON
@@ -44,7 +44,7 @@ SRC    ?= $(shell find . -type f -name "*.go" ! -path "./.build/*")
 GOOS   ?= $(shell uname | tr A-Z a-z)
 GOARCH ?= $(subst x86_64,amd64,$(patsubst i%86,386,$(shell uname -m)))
 
-GO_VERSION ?= 1.5.3
+GO_VERSION ?= 1.6
 GOPATH     ?= $(CURDIR)/.build/gopath
 ROOTPKG    ?= github.com/prometheus/$(TARGET)
 SELFLINK   ?= $(GOPATH)/src/$(ROOTPKG)

--- a/haproxy_exporter_test.go
+++ b/haproxy_exporter_test.go
@@ -55,7 +55,7 @@ func TestInvalidConfig(t *testing.T) {
 	h := newHaproxy([]byte("not,enough,fields"))
 	defer h.Close()
 
-	e := NewExporter(h.URL, serverMetrics, 5*time.Second)
+	e := NewExporter(h.URL, serverMetrics, 5*time.Second, "", "")
 	ch := make(chan prometheus.Metric)
 
 	go func() {
@@ -84,7 +84,7 @@ func TestServerWithoutChecks(t *testing.T) {
 	h := newHaproxy([]byte("test,127.0.0.1:8080,0,0,0,0,,0,0,0,,0,,0,0,0,0,no check,1,1,0,,,,,,1,1,1,,0,,2,0,,0,,,,0,0,0,0,0,0,0,,,,0,0,"))
 	defer h.Close()
 
-	e := NewExporter(h.URL, serverMetrics, 5*time.Second)
+	e := NewExporter(h.URL, serverMetrics, 5*time.Second, "", "")
 	ch := make(chan prometheus.Metric)
 
 	go func() {
@@ -127,7 +127,7 @@ foo,BACKEND,0,0,0,0,,0,0,0,,0,,0,0,0,0,UP,1,1,0,0,0,5007,0,,1,8,1,,0,,2,0,,0,L4O
 	h := newHaproxy([]byte(data))
 	defer h.Close()
 
-	e := NewExporter(h.URL, serverMetrics, 5*time.Second)
+	e := NewExporter(h.URL, serverMetrics, 5*time.Second, "", "")
 	ch := make(chan prometheus.Metric)
 
 	go func() {
@@ -161,7 +161,7 @@ func TestConfigChangeDetection(t *testing.T) {
 	h := newHaproxy([]byte(""))
 	defer h.Close()
 
-	e := NewExporter(h.URL, serverMetrics, 5*time.Second)
+	e := NewExporter(h.URL, serverMetrics, 5*time.Second, "", "")
 	ch := make(chan prometheus.Metric)
 
 	go func() {
@@ -188,7 +188,7 @@ func TestDeadline(t *testing.T) {
 		s.Close()
 	}()
 
-	e := NewExporter(s.URL, serverMetrics, 1*time.Second)
+	e := NewExporter(s.URL, serverMetrics, 1*time.Second, "", "")
 	ch := make(chan prometheus.Metric)
 	go func() {
 		defer close(ch)
@@ -275,7 +275,7 @@ func BenchmarkExtract(b *testing.B) {
 	h := newHaproxy(config)
 	defer h.Close()
 
-	e := NewExporter(h.URL, serverMetrics, 5*time.Second)
+	e := NewExporter(h.URL, serverMetrics, 5*time.Second, "", "")
 
 	var before, after runtime.MemStats
 	runtime.GC()


### PR DESCRIPTION
Hi

I needed this to work with a haproxy that had basic auth implemented.
I have updated the go build version to 1.6 because that is what we use locally, if this is not idea I can revert the change. Also welcome any other changes regarding how the code should be structured to fit into the repo going forward.

Thanks

@juliusv @brian-brazil 