### PR TITLE
Add `-scrape.uri` examples to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,31 @@ go run haproxy_exporter --help
 
 [![Build Status](https://travis-ci.org/prometheus/haproxy_exporter.png?branch=master)](https://travis-ci.org/prometheus/haproxy_exporter)
 
+## Custom HAProxy stats URL
+
+Specify custom URLs for the HAProxy stats port using the `-haproxy.scrape-uri` flag. For example, if you have set `stats uri /baz`,
+
+```bash
+haproxy_exporter -haproxy.scrape-uri="http://user:pass@localhost:5000/baz?stats;csv"
+```
+
+Or to scrape a remote host
+
+```bash
+haproxy_exporter -haproxy.scrape-uri="http://haproxy.example.com/haproxy?stats;csv"
+```
+
+Note that the `;csv` is mandatory (and needs to be quoted).
+
+
+## Basic Auth
+
+If your stats port is protected by [basic auth](https://cbonte.github.io/haproxy-dconv/configuration-1.6.html#4-stats%20auth), add the credentials to the scrape URL:
+
+```bash
+haproxy_exporter  -haproxy.scrape-uri="http://user:pass@haproxy.example.com/haproxy?stats;csv"
+```
+
 ## Docker
 
 To run the haproxy exporter as a Docker container, run:


### PR DESCRIPTION
To reduce confusion (cf. #49), make it clear that this is supported and
how to use it.

@brian-brazil @grobie 