### PR TITLE
Ensure consistent metrics by adding process label.

### DIFF
--- a/haproxy_exporter.go
+++ b/haproxy_exporter.go
@@ -33,9 +33,9 @@ const (
 )
 
 var (
-	frontendLabelNames = []string{"frontend"}
-	backendLabelNames  = []string{"backend"}
-	serverLabelNames   = []string{"backend", "server"}
+	frontendLabelNames = []string{"pid", "frontend"}
+	backendLabelNames  = []string{"pid", "backend"}
+	serverLabelNames   = []string{"pid", "backend", "server"}
 )
 
 func newFrontendMetric(metricName string, docString string, constLabels prometheus.Labels) *prometheus.GaugeVec {
@@ -315,7 +315,7 @@ func (e *Exporter) parseRow(csvRow []string) {
 		return
 	}
 
-	pxname, svname, type_ := csvRow[0], csvRow[1], csvRow[32]
+	pxname, svname, pid, type_ := csvRow[0], csvRow[1], csvRow[26], csvRow[32]
 
 	const (
 		frontend = "0"
@@ -326,11 +326,11 @@ func (e *Exporter) parseRow(csvRow []string) {
 
 	switch type_ {
 	case frontend:
-		e.exportCsvFields(e.frontendMetrics, csvRow, pxname)
+		e.exportCsvFields(e.frontendMetrics, csvRow, pid, pxname)
 	case backend:
-		e.exportCsvFields(e.backendMetrics, csvRow, pxname)
+		e.exportCsvFields(e.backendMetrics, csvRow, pid, pxname)
 	case server:
-		e.exportCsvFields(e.serverMetrics, csvRow, pxname, svname)
+		e.exportCsvFields(e.serverMetrics, csvRow, pid, pxname, svname)
 	}
 }
 

--- a/haproxy_exporter.go
+++ b/haproxy_exporter.go
@@ -33,9 +33,9 @@ const (
 )
 
 var (
-	frontendLabelNames = []string{"pid", "frontend"}
-	backendLabelNames  = []string{"pid", "backend"}
-	serverLabelNames   = []string{"pid", "backend", "server"}
+	frontendLabelNames = []string{"process", "frontend"}
+	backendLabelNames  = []string{"process", "backend"}
+	serverLabelNames   = []string{"process", "backend", "server"}
 )
 
 func newFrontendMetric(metricName string, docString string, constLabels prometheus.Labels) *prometheus.GaugeVec {
@@ -315,7 +315,7 @@ func (e *Exporter) parseRow(csvRow []string) {
 		return
 	}
 
-	pxname, svname, pid, type_ := csvRow[0], csvRow[1], csvRow[26], csvRow[32]
+	pxname, svname, process, type_ := csvRow[0], csvRow[1], csvRow[26], csvRow[32]
 
 	const (
 		frontend = "0"
@@ -326,11 +326,11 @@ func (e *Exporter) parseRow(csvRow []string) {
 
 	switch type_ {
 	case frontend:
-		e.exportCsvFields(e.frontendMetrics, csvRow, pid, pxname)
+		e.exportCsvFields(e.frontendMetrics, csvRow, process, pxname)
 	case backend:
-		e.exportCsvFields(e.backendMetrics, csvRow, pid, pxname)
+		e.exportCsvFields(e.backendMetrics, csvRow, process, pxname)
 	case server:
-		e.exportCsvFields(e.serverMetrics, csvRow, pid, pxname, svname)
+		e.exportCsvFields(e.serverMetrics, csvRow, process, pxname, svname)
 	}
 }
 


### PR DESCRIPTION
This is a first step toward a better output for multi-process HAProxy setup.
By adding a pid label we don't get erroneous metrics (1 set of metrics per process) but at random interval.

Next step would be to use unix socket (#53) to get process count (by parsing`show info`) and all processes metrics (by iterating `show stat bind-process <pid>`)