### PR TITLE
Fix timeout and keepalive by using Client.Timeout

### DIFF
--- a/haproxy_exporter.go
+++ b/haproxy_exporter.go
@@ -249,18 +249,7 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 
 func fetchHTTP(uri string, timeout time.Duration) func() (io.ReadCloser, error) {
 	client := http.Client{
-		Transport: &http.Transport{
-			Dial: func(netw, addr string) (net.Conn, error) {
-				c, err := net.DialTimeout(netw, addr, timeout)
-				if err != nil {
-					return nil, err
-				}
-				if err := c.SetDeadline(time.Now().Add(timeout)); err != nil {
-					return nil, err
-				}
-				return c, nil
-			},
-		},
+		Timeout: timeout,
 	}
 
 	return func() (io.ReadCloser, error) {


### PR DESCRIPTION
With net.Conn.SetDeadline the connection could not be reused for
additional requests after the timeout, and even a fast response could
time out while reading, because the timer was started by a previous
request.

With a five second scrape interval, the log will fill up with this
error:

    ERRO[0108] Unexpected error while reading CSV: read tcp n.n.n.n:57648->m.m.m.m:443: i/o timeout source=haproxy_exporter.go:331

With this change I can not see any more errors and by using netstat I
can see that the same port/connection is reused for a while.

I used 5 seconds for testing, and I guess it's not often used in production, but I think having keepalive working is worth fixing.  See also:

    https://golang.org/pkg/net/http/#Client
    https://medium.com/@nate510/don-t-use-go-s-default-http-client-4804cb19f779#9b34

@discordianfish 