### PR TITLE
Use a proper type assertion when checking for csv.ParseError

### DIFF
--- a/haproxy_exporter.go
+++ b/haproxy_exporter.go
@@ -312,11 +312,12 @@ loop:
 		case nil:
 		case io.EOF:
 			break loop
-		case err.(*csv.ParseError):
-			log.Errorf("Can't read CSV: %v", err)
-			e.csvParseFailures.Inc()
-			continue loop
 		default:
+			if _, ok := err.(*csv.ParseError); ok {
+				log.Errorf("Can't read CSV: %v", err)
+				e.csvParseFailures.Inc()
+				continue loop
+			}
 			log.Errorf("Unexpected error while reading CSV: %v", err)
 			e.up.Set(0)
 			break loop


### PR DESCRIPTION
While the former way seems to work as intended, the behavior is at best
undocumented.

@beorn7 