### PR TITLE
Add column 6 ("slim [LFBS]: configured session limit") to serverMetrics

### DIFF
--- a/haproxy_exporter.go
+++ b/haproxy_exporter.go
@@ -97,6 +97,7 @@ var (
 		3:  newServerMetric("max_queue", "Maximum observed number of queued requests assigned to this server.", nil),
 		4:  newServerMetric("current_sessions", "Current number of active sessions.", nil),
 		5:  newServerMetric("max_sessions", "Maximum observed number of active sessions.", nil),
+		6:  newServerMetric("limit_sessions", "Configured session limit.", nil),
 		7:  newServerMetric("connections_total", "Total number of connections.", nil),
 		8:  newServerMetric("bytes_in_total", "Current total of incoming bytes.", nil),
 		9:  newServerMetric("bytes_out_total", "Current total of outgoing bytes.", nil),

--- a/haproxy_exporter_test.go
+++ b/haproxy_exporter_test.go
@@ -87,7 +87,7 @@ func TestInvalidConfig(t *testing.T) {
 }
 
 func TestServerWithoutChecks(t *testing.T) {
-	h := newHaproxy([]byte("test,127.0.0.1:8080,0,0,0,0,,0,0,0,,0,,0,0,0,0,no check,1,1,0,0,,,0,,1,1,1,,0,,2,0,,0,,,,0,0,0,0,0,0,0,,,,0,0,"))
+	h := newHaproxy([]byte("test,127.0.0.1:8080,0,0,0,0,0,0,0,0,,0,,0,0,0,0,no check,1,1,0,0,,,0,,1,1,1,,0,,2,0,,0,,,,0,0,0,0,0,0,0,,,,0,0,"))
 	defer h.Close()
 
 	e, _ := NewExporter(h.URL, serverMetrics, 5*time.Second)
@@ -285,7 +285,7 @@ func TestUnixDomain(t *testing.T) {
 		t.Skip("not on windows")
 		return
 	}
-	srv, err := newHaproxyUnix(testSocket, "test,127.0.0.1:8080,0,0,0,0,,0,0,0,,0,,0,0,0,0,no check,1,1,0,0,,,0,,1,1,1,,0,,2,0,,0,,,,0,0,0,0,0,0,0,,,,0,0,\n")
+	srv, err := newHaproxyUnix(testSocket, "test,127.0.0.1:8080,0,0,0,0,0,0,0,0,,0,,0,0,0,0,no check,1,1,0,0,,,0,,1,1,1,,0,,2,0,,0,,,,0,0,0,0,0,0,0,,,,0,0,\n")
 	if err != nil {
 		t.Fatalf("can't start test server: %v", err)
 	}


### PR DESCRIPTION
@brian-brazil  ... this pull request adds column 6, ("slim [LFBS]:") which contains the session limit for each individual server. 

The value can be used i.e. to compare to the number of currently active connections, so it is very much of interest and not just a to some extend "static" piece of configuration. 