### PR TITLE
Improve help text of -haproxy.pid-file flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ core developers are accessible via the Prometheus Developers [mailinglist][].
 
 ### HTTP stats URL
 
-Specify custom URLs for the HAProxy stats port using the `-haproxy.scrape-uri` flag. For example, if you have set `stats uri /baz`,
+Specify custom URLs for the HAProxy stats port using the `-haproxy.scrape-uri`
+flag. For example, if you have set `stats uri /baz`,
 
 ```bash
 haproxy_exporter -haproxy.scrape-uri="http://localhost:5000/baz?stats;csv"
@@ -41,11 +42,14 @@ haproxy_exporter -haproxy.scrape-uri="http://haproxy.example.com/haproxy?stats;c
 
 Note that the `;csv` is mandatory (and needs to be quoted).
 
-If your stats port is protected by [basic auth](https://cbonte.github.io/haproxy-dconv/configuration-1.6.html#4-stats%20auth), add the credentials to the scrape URL:
+If your stats port is protected by [basic auth][], add the credentials to the
+scrape URL:
 
 ```bash
 haproxy_exporter  -haproxy.scrape-uri="http://user:pass@haproxy.example.com/haproxy?stats;csv"
 ```
+
+[basic auth]: https://cbonte.github.io/haproxy-dconv/configuration-1.6.html#4-stats%20auth
 
 ### Unix Sockets
 

--- a/haproxy_exporter.go
+++ b/haproxy_exporter.go
@@ -437,13 +437,22 @@ func filterServerMetrics(filter string) (map[int]*prometheus.GaugeVec, error) {
 }
 
 func main() {
+	const pidFileHelpText = `Path to HAProxy pid file.
+
+	If provided, the standard process metrics get exported for the HAProxy
+	process, prefixed with 'haproxy_process_...'. The haproxy_process exporter
+	needs to have read access to files owned by the HAProxy process. Depends on
+	the availability of /proc.
+
+	https://prometheus.io/docs/instrumenting/writing_clientlibs/#process-metrics.`
+
 	var (
 		listenAddress             = flag.String("web.listen-address", ":9101", "Address to listen on for web interface and telemetry.")
 		metricsPath               = flag.String("web.telemetry-path", "/metrics", "Path under which to expose metrics.")
 		haProxyScrapeURI          = flag.String("haproxy.scrape-uri", "http://localhost/;csv", "URI on which to scrape HAProxy.")
 		haProxyServerMetricFields = flag.String("haproxy.server-metric-fields", serverMetrics.String(), "Comma-separated list of exported server metrics. See http://cbonte.github.io/haproxy-dconv/configuration-1.5.html#9.1")
 		haProxyTimeout            = flag.Duration("haproxy.timeout", 5*time.Second, "Timeout for trying to get stats from HAProxy.")
-		haProxyPidFile            = flag.String("haproxy.pid-file", "", "Path to haproxy's pid file.")
+		haProxyPidFile            = flag.String("haproxy.pid-file", "", pidFileHelpText)
 		showVersion               = flag.Bool("version", false, "Print version information.")
 	)
 	flag.Parse()


### PR DESCRIPTION
Fixes #70.

```
Usage of ./haproxy_exporter:
  -haproxy.pid-file string
        Path to HAProxy pid file.

        If provided, the standard process metrics get exported for the HAProxy
        process, prefixed with 'haproxy_process_...'. The haproxy_process exporter
        needs to have read access to files owned by the HAProxy process. Depends on
        the availability of /proc.

        https://prometheus.io/docs/instrumenting/writing_clientlibs/#process-metrics.
  -haproxy.scrape-uri string
        URI on which to scrape HAProxy. (default "http://localhost/;csv")
  ...
```
@JensRantil 