### PR TITLE
New insecure flag

### DIFF
--- a/haproxy_exporter.go
+++ b/haproxy_exporter.go
@@ -125,10 +125,9 @@ var (
 // Exporter collects HAProxy stats from the given URI and exports them using
 // the prometheus metrics package.
 type Exporter struct {
-	URI      string
-	insecure bool
-	mutex    sync.RWMutex
-	fetch    func() (io.ReadCloser, error)
+	URI   string
+	mutex sync.RWMutex
+	fetch func() (io.ReadCloser, error)
 
 	up                                             prometheus.Gauge
 	totalScrapes, csvParseFailures                 prometheus.Counter

--- a/haproxy_exporter_test.go
+++ b/haproxy_exporter_test.go
@@ -317,7 +317,7 @@ func TestUnixDomain(t *testing.T) {
 
 	got := 0
 	for range ch {
-		got += 1
+		got++
 	}
 	if expect := len(e.serverMetrics) - 1; got != expect {
 		t.Errorf("expected %d metrics, got %d", expect, got)

--- a/haproxy_exporter_test.go
+++ b/haproxy_exporter_test.go
@@ -61,7 +61,7 @@ func TestInvalidConfig(t *testing.T) {
 	h := newHaproxy([]byte("not,enough,fields"))
 	defer h.Close()
 
-	e, _ := NewExporter(h.URL, serverMetrics, 5*time.Second)
+	e, _ := NewExporter(h.URL, serverMetrics, 5*time.Second, false)
 	ch := make(chan prometheus.Metric)
 
 	go func() {
@@ -90,7 +90,7 @@ func TestServerWithoutChecks(t *testing.T) {
 	h := newHaproxy([]byte("test,127.0.0.1:8080,0,0,0,0,0,0,0,0,,0,,0,0,0,0,no check,1,1,0,0,,,0,,1,1,1,,0,,2,0,,0,,,,0,0,0,0,0,0,0,,,,0,0,"))
 	defer h.Close()
 
-	e, _ := NewExporter(h.URL, serverMetrics, 5*time.Second)
+	e, _ := NewExporter(h.URL, serverMetrics, 5*time.Second, false)
 	ch := make(chan prometheus.Metric)
 
 	go func() {
@@ -133,7 +133,7 @@ foo,BACKEND,0,0,0,0,,0,0,0,,0,,0,0,0,0,UP,1,1,0,0,0,5007,0,,1,8,1,,0,,2,0,,0,L4O
 	h := newHaproxy([]byte(data))
 	defer h.Close()
 
-	e, _ := NewExporter(h.URL, serverMetrics, 5*time.Second)
+	e, _ := NewExporter(h.URL, serverMetrics, 5*time.Second, false)
 	ch := make(chan prometheus.Metric)
 
 	go func() {
@@ -167,7 +167,7 @@ func TestConfigChangeDetection(t *testing.T) {
 	h := newHaproxy([]byte(""))
 	defer h.Close()
 
-	e, _ := NewExporter(h.URL, serverMetrics, 5*time.Second)
+	e, _ := NewExporter(h.URL, serverMetrics, 5*time.Second, false)
 	ch := make(chan prometheus.Metric)
 
 	go func() {
@@ -194,7 +194,7 @@ func TestDeadline(t *testing.T) {
 		s.Close()
 	}()
 
-	e, err := NewExporter(s.URL, serverMetrics, 1*time.Second)
+	e, err := NewExporter(s.URL, serverMetrics, 1*time.Second, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -226,7 +226,7 @@ func TestNotFound(t *testing.T) {
 	s := httptest.NewServer(http.NotFoundHandler())
 	defer s.Close()
 
-	e, err := NewExporter(s.URL, serverMetrics, 1*time.Second)
+	e, err := NewExporter(s.URL, serverMetrics, 1*time.Second, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -291,7 +291,7 @@ func TestUnixDomain(t *testing.T) {
 	}
 	defer srv.Close()
 
-	e, err := NewExporter("unix:"+testSocket, serverMetrics, 5*time.Second)
+	e, err := NewExporter("unix:"+testSocket, serverMetrics, 5*time.Second, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -333,7 +333,7 @@ func TestUnixDomainNotFound(t *testing.T) {
 	if err := os.Remove(testSocket); err != nil && !os.IsNotExist(err) {
 		t.Fatal(err)
 	}
-	e, _ := NewExporter("unix:"+testSocket, serverMetrics, 1*time.Second)
+	e, _ := NewExporter("unix:"+testSocket, serverMetrics, 1*time.Second, false)
 	ch := make(chan prometheus.Metric)
 	go func() {
 		defer close(ch)
@@ -386,7 +386,7 @@ func TestUnixDomainDeadline(t *testing.T) {
 		}
 	}()
 
-	e, _ := NewExporter("unix:"+testSocket, serverMetrics, 1*time.Second)
+	e, _ := NewExporter("unix:"+testSocket, serverMetrics, 1*time.Second, false)
 	ch := make(chan prometheus.Metric)
 	go func() {
 		defer close(ch)
@@ -411,7 +411,7 @@ func TestUnixDomainDeadline(t *testing.T) {
 }
 
 func TestInvalidScheme(t *testing.T) {
-	e, err := NewExporter("gopher://gopher.quux.org", serverMetrics, 1*time.Second)
+	e, err := NewExporter("gopher://gopher.quux.org", serverMetrics, 1*time.Second, false)
 	if expect, got := (*Exporter)(nil), e; expect != got {
 		t.Errorf("expected %v, got %v", expect, got)
 	}
@@ -486,7 +486,7 @@ func BenchmarkExtract(b *testing.B) {
 	h := newHaproxy(config)
 	defer h.Close()
 
-	e, _ := NewExporter(h.URL, serverMetrics, 5*time.Second)
+	e, _ := NewExporter(h.URL, serverMetrics, 5*time.Second, false)
 
 	var before, after runtime.MemStats
 	runtime.GC()


### PR DESCRIPTION
Hi @grobie , we have an issue with certificate validation when scraping from inside VPN.
in order to bypass this, i added an insecure flag. maybe it helps somebody else.

for sure it is not the best solution, but i am willing to learn if i made mistakes :) 
```
Can't scrape HAProxy: Get https://foo.bar.somedomain.io/stats;csv: x509: certificate is valid for *.somedomain.io, somedomain.io, not foo.bar.somedomain.io  source=haproxy_exporter.go:298
``` 
