### PR TITLE
HTTPS support with insecure verify option

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,13 @@ scrape URL:
 haproxy_exporter  --haproxy.scrape-uri="http://user:pass@haproxy.example.com/haproxy?stats;csv"
 ```
 
+You can also scrape HTTPS URLs. Certificate validation is enabled by default, but
+you can disable it using the `--haproxy.ssl-verify=false` flag:
+
+```bash
+haproxy_exporter --haproxy.ssl-verify=false --haproxy.scrape-uri="https://haproxy.example.com/haproxy?stats;csv"
+```
+
 [basic auth]: https://cbonte.github.io/haproxy-dconv/configuration-1.6.html#4-stats%20auth
 
 ### Unix Sockets

--- a/haproxy_exporter.go
+++ b/haproxy_exporter.go
@@ -255,13 +255,10 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 }
 
 func fetchHTTP(uri string, sslVerify bool, timeout time.Duration) func() (io.ReadCloser, error) {
+	tr := &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: !sslVerify}}
 	client := http.Client{
-		Timeout: timeout,
-	}
-
-	if !sslVerify {
-		tr := &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}
-		client.Transport = tr
+		Timeout:   timeout,
+		Transport: tr,
 	}
 
 	return func() (io.ReadCloser, error) {

--- a/haproxy_exporter_test.go
+++ b/haproxy_exporter_test.go
@@ -61,7 +61,7 @@ func TestInvalidConfig(t *testing.T) {
 	h := newHaproxy([]byte("not,enough,fields"))
 	defer h.Close()
 
-	e, _ := NewExporter(h.URL, serverMetrics, 5*time.Second)
+	e, _ := NewExporter(h.URL, true, serverMetrics, 5*time.Second)
 	ch := make(chan prometheus.Metric)
 
 	go func() {
@@ -90,7 +90,7 @@ func TestServerWithoutChecks(t *testing.T) {
 	h := newHaproxy([]byte("test,127.0.0.1:8080,0,0,0,0,0,0,0,0,,0,,0,0,0,0,no check,1,1,0,0,,,0,,1,1,1,,0,,2,0,,0,,,,0,0,0,0,0,0,0,,,,0,0,,,,,,,,,,,"))
 	defer h.Close()
 
-	e, _ := NewExporter(h.URL, serverMetrics, 5*time.Second)
+	e, _ := NewExporter(h.URL, true, serverMetrics, 5*time.Second)
 	ch := make(chan prometheus.Metric)
 
 	go func() {
@@ -133,7 +133,7 @@ foo,BACKEND,0,0,0,0,,0,0,0,,0,,0,0,0,0,UP,1,1,0,0,0,5007,0,,1,8,1,,0,,2,0,,0,L4O
 	h := newHaproxy([]byte(data))
 	defer h.Close()
 
-	e, _ := NewExporter(h.URL, serverMetrics, 5*time.Second)
+	e, _ := NewExporter(h.URL, true, serverMetrics, 5*time.Second)
 	ch := make(chan prometheus.Metric)
 
 	go func() {
@@ -171,7 +171,7 @@ foo,BACKEND,0,0,0,0,,0,0,0,,0,,0,0,0,0,UP,1,1,0,0,0,5007,0,,1,8,1,,0,,2,
 	h := newHaproxy([]byte(data))
 	defer h.Close()
 
-	e, _ := NewExporter(h.URL, serverMetrics, 5*time.Second)
+	e, _ := NewExporter(h.URL, true, serverMetrics, 5*time.Second)
 	ch := make(chan prometheus.Metric)
 
 	go func() {
@@ -201,7 +201,7 @@ func TestConfigChangeDetection(t *testing.T) {
 	h := newHaproxy([]byte(""))
 	defer h.Close()
 
-	e, _ := NewExporter(h.URL, serverMetrics, 5*time.Second)
+	e, _ := NewExporter(h.URL, true, serverMetrics, 5*time.Second)
 	ch := make(chan prometheus.Metric)
 
 	go func() {
@@ -228,7 +228,7 @@ func TestDeadline(t *testing.T) {
 		s.Close()
 	}()
 
-	e, err := NewExporter(s.URL, serverMetrics, 1*time.Second)
+	e, err := NewExporter(s.URL, true, serverMetrics, 1*time.Second)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -260,7 +260,7 @@ func TestNotFound(t *testing.T) {
 	s := httptest.NewServer(http.NotFoundHandler())
 	defer s.Close()
 
-	e, err := NewExporter(s.URL, serverMetrics, 1*time.Second)
+	e, err := NewExporter(s.URL, true, serverMetrics, 1*time.Second)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -325,7 +325,7 @@ func TestUnixDomain(t *testing.T) {
 	}
 	defer srv.Close()
 
-	e, err := NewExporter("unix:"+testSocket, serverMetrics, 5*time.Second)
+	e, err := NewExporter("unix:"+testSocket, true, serverMetrics, 5*time.Second)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -367,7 +367,7 @@ func TestUnixDomainNotFound(t *testing.T) {
 	if err := os.Remove(testSocket); err != nil && !os.IsNotExist(err) {
 		t.Fatal(err)
 	}
-	e, _ := NewExporter("unix:"+testSocket, serverMetrics, 1*time.Second)
+	e, _ := NewExporter("unix:"+testSocket, true, serverMetrics, 1*time.Second)
 	ch := make(chan prometheus.Metric)
 	go func() {
 		defer close(ch)
@@ -420,7 +420,7 @@ func TestUnixDomainDeadline(t *testing.T) {
 		}
 	}()
 
-	e, _ := NewExporter("unix:"+testSocket, serverMetrics, 1*time.Second)
+	e, _ := NewExporter("unix:"+testSocket, true, serverMetrics, 1*time.Second)
 	ch := make(chan prometheus.Metric)
 	go func() {
 		defer close(ch)
@@ -445,7 +445,7 @@ func TestUnixDomainDeadline(t *testing.T) {
 }
 
 func TestInvalidScheme(t *testing.T) {
-	e, err := NewExporter("gopher://gopher.quux.org", serverMetrics, 1*time.Second)
+	e, err := NewExporter("gopher://gopher.quux.org", true, serverMetrics, 1*time.Second)
 	if expect, got := (*Exporter)(nil), e; expect != got {
 		t.Errorf("expected %v, got %v", expect, got)
 	}
@@ -520,7 +520,7 @@ func BenchmarkExtract(b *testing.B) {
 	h := newHaproxy(config)
 	defer h.Close()
 
-	e, _ := NewExporter(h.URL, serverMetrics, 5*time.Second)
+	e, _ := NewExporter(h.URL, true, serverMetrics, 5*time.Second)
 
 	var before, after runtime.MemStats
 	runtime.GC()


### PR DESCRIPTION
In one of my projects haproxy_exporter is located on a different machine and should be able to communicate via HTTPS with certificate verification disabled.
Here is the pull request that solves the problem.

This pull request addresses Issue #74.