### PR TITLE
Configure scrape-uri via environment variable

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -37,7 +37,6 @@ test:
 deployment:
   hub_branch:
     branch: master
-    owner: prometheus
     commands:
       - docker login -e $DOCKER_EMAIL -u $DOCKER_LOGIN -p $DOCKER_PASSWORD
       - docker login -e $QUAY_EMAIL -u $QUAY_LOGIN -p $QUAY_PASSWORD quay.io
@@ -45,7 +44,6 @@ deployment:
       - docker push $QUAY_IMAGE_NAME
   hub_tag:
     tag: /^v[0-9]+(\.[0-9]+){2}(-.+|[^-.]*)$/
-    owner: prometheus
     commands:
       - promu crossbuild tarballs
       - promu checksum .tarballs

--- a/circle.yml
+++ b/circle.yml
@@ -35,12 +35,15 @@ test:
     - docker run --rm -t -v "$(pwd):/app" "${DOCKER_TEST_IMAGE_NAME}" -i "${REPO_PATH}" -T
 
 deployment:
-  hub_branch:
+  docker_branch:
     branch: master
     commands:
       - docker login -e $DOCKER_EMAIL -u $DOCKER_LOGIN -p $DOCKER_PASSWORD
-      - docker login -e $QUAY_EMAIL -u $QUAY_LOGIN -p $QUAY_PASSWORD quay.io
       - docker push $DOCKER_IMAGE_NAME
+  qay_branch:
+    branch: master
+    commands:
+      - docker login -e $QUAY_EMAIL -u $QUAY_LOGIN -p $QUAY_PASSWORD quay.io
       - docker push $QUAY_IMAGE_NAME
   hub_tag:
     tag: /^v[0-9]+(\.[0-9]+){2}(-.+|[^-.]*)$/

--- a/haproxy_exporter.go
+++ b/haproxy_exporter.go
@@ -475,7 +475,7 @@ func main() {
 	var (
 		listenAddress             = kingpin.Flag("web.listen-address", "Address to listen on for web interface and telemetry.").Default(":9101").String()
 		metricsPath               = kingpin.Flag("web.telemetry-path", "Path under which to expose metrics.").Default("/metrics").String()
-		haProxyScrapeURI          = kingpin.Flag("haproxy.scrape-uri", "URI on which to scrape HAProxy.").Default("http://localhost/;csv").String()
+		haProxyScrapeURI          = kingpin.Flag("haproxy.scrape-uri", "URI on which to scrape HAProxy.").Default("http://localhost/;csv").OverrideDefaultFromEnvar("HAPROXY_EXPORTER_SCRAPE_URI").String()
 		haProxySSLVerify          = kingpin.Flag("haproxy.ssl-verify", "Flag that enables SSL certificate verification for the scrape URI").Default("true").Bool()
 		haProxyServerMetricFields = kingpin.Flag("haproxy.server-metric-fields", "Comma-separated list of exported server metrics. See http://cbonte.github.io/haproxy-dconv/configuration-1.5.html#9.1").Default(serverMetrics.String()).String()
 		haProxyTimeout            = kingpin.Flag("haproxy.timeout", "Timeout for trying to get stats from HAProxy.").Default("5s").Duration()


### PR DESCRIPTION
Support configuration of --haproxy.scrape-uri via an environment variable. The URI can contain username:password combination and might be visible on Linux using a simple ps(1) command. This commit allows to use haproxy_exporter with docker as follows:

    docker -e HAPROXY_EXPORTER_SCRAPE_URI=https://username:password@haproxy.my.corp:9001/statistics;csv

As a matter of policy the official project does not allow configuration via any sources other than command line flags and configuration files. This serves as a temporary solution until a configuration file has been added to the exporter.