### PR TITLE
Convert HAProxy Exporter to using const metrics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/mattn/go-isatty v0.0.4 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v0.9.2
-	github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910
 	github.com/prometheus/common v0.0.0-20181126121408-4724e9255275
 	github.com/sergi/go-diff v1.0.0 // indirect
 	github.com/sirupsen/logrus v0.0.0-20160425093237-cd7d1bbe4106 // indirect

--- a/haproxy_exporter.go
+++ b/haproxy_exporter.go
@@ -62,43 +62,19 @@ var (
 	serverLabelNames   = []string{"backend", "server"}
 )
 
-func newFrontendMetric(metricName string, docString string, constLabels prometheus.Labels) *prometheus.GaugeVec {
-	return prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Namespace:   namespace,
-			Name:        "frontend_" + metricName,
-			Help:        docString,
-			ConstLabels: constLabels,
-		},
-		frontendLabelNames,
-	)
+func newFrontendMetric(metricName string, docString string, constLabels prometheus.Labels) *prometheus.Desc {
+	return prometheus.NewDesc(prometheus.BuildFQName(namespace, "frontend", metricName), docString, frontendLabelNames, constLabels)
 }
 
-func newBackendMetric(metricName string, docString string, constLabels prometheus.Labels) *prometheus.GaugeVec {
-	return prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Namespace:   namespace,
-			Name:        "backend_" + metricName,
-			Help:        docString,
-			ConstLabels: constLabels,
-		},
-		backendLabelNames,
-	)
+func newBackendMetric(metricName string, docString string, constLabels prometheus.Labels) *prometheus.Desc {
+	return prometheus.NewDesc(prometheus.BuildFQName(namespace, "backend", metricName), docString, backendLabelNames, constLabels)
 }
 
-func newServerMetric(metricName string, docString string, constLabels prometheus.Labels) *prometheus.GaugeVec {
-	return prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Namespace:   namespace,
-			Name:        "server_" + metricName,
-			Help:        docString,
-			ConstLabels: constLabels,
-		},
-		serverLabelNames,
-	)
+func newServerMetric(metricName string, docString string, constLabels prometheus.Labels) *prometheus.Desc {
+	return prometheus.NewDesc(prometheus.BuildFQName(namespace, "server", metricName), docString, serverLabelNames, constLabels)
 }
 
-type metrics map[int]*prometheus.GaugeVec
+type metrics map[int]*prometheus.Desc
 
 func (m metrics) String() string {
 	keys := make([]int, 0, len(m))
@@ -141,6 +117,59 @@ var (
 		43: newServerMetric("http_responses_total", "Total of HTTP responses.", prometheus.Labels{"code": "5xx"}),
 		44: newServerMetric("http_responses_total", "Total of HTTP responses.", prometheus.Labels{"code": "other"}),
 	}
+
+	frontendMetrics = metrics{
+		4:  newFrontendMetric("current_sessions", "Current number of active sessions.", nil),
+		5:  newFrontendMetric("max_sessions", "Maximum observed number of active sessions.", nil),
+		6:  newFrontendMetric("limit_sessions", "Configured session limit.", nil),
+		7:  newFrontendMetric("sessions_total", "Total number of sessions.", nil),
+		8:  newFrontendMetric("bytes_in_total", "Current total of incoming bytes.", nil),
+		9:  newFrontendMetric("bytes_out_total", "Current total of outgoing bytes.", nil),
+		10: newFrontendMetric("requests_denied_total", "Total of requests denied for security.", nil),
+		12: newFrontendMetric("request_errors_total", "Total of request errors.", nil),
+		33: newFrontendMetric("current_session_rate", "Current number of sessions per second over last elapsed second.", nil),
+		34: newFrontendMetric("limit_session_rate", "Configured limit on new sessions per second.", nil),
+		35: newFrontendMetric("max_session_rate", "Maximum observed number of sessions per second.", nil),
+		39: newFrontendMetric("http_responses_total", "Total of HTTP responses.", prometheus.Labels{"code": "1xx"}),
+		40: newFrontendMetric("http_responses_total", "Total of HTTP responses.", prometheus.Labels{"code": "2xx"}),
+		41: newFrontendMetric("http_responses_total", "Total of HTTP responses.", prometheus.Labels{"code": "3xx"}),
+		42: newFrontendMetric("http_responses_total", "Total of HTTP responses.", prometheus.Labels{"code": "4xx"}),
+		43: newFrontendMetric("http_responses_total", "Total of HTTP responses.", prometheus.Labels{"code": "5xx"}),
+		44: newFrontendMetric("http_responses_total", "Total of HTTP responses.", prometheus.Labels{"code": "other"}),
+		48: newFrontendMetric("http_requests_total", "Total HTTP requests.", nil),
+		79: newFrontendMetric("connections_total", "Total number of connections", nil),
+	}
+	backendMetrics = metrics{
+		2:  newBackendMetric("current_queue", "Current number of queued requests not assigned to any server.", nil),
+		3:  newBackendMetric("max_queue", "Maximum observed number of queued requests not assigned to any server.", nil),
+		4:  newBackendMetric("current_sessions", "Current number of active sessions.", nil),
+		5:  newBackendMetric("max_sessions", "Maximum observed number of active sessions.", nil),
+		6:  newBackendMetric("limit_sessions", "Configured session limit.", nil),
+		7:  newBackendMetric("sessions_total", "Total number of sessions.", nil),
+		8:  newBackendMetric("bytes_in_total", "Current total of incoming bytes.", nil),
+		9:  newBackendMetric("bytes_out_total", "Current total of outgoing bytes.", nil),
+		13: newBackendMetric("connection_errors_total", "Total of connection errors.", nil),
+		14: newBackendMetric("response_errors_total", "Total of response errors.", nil),
+		15: newBackendMetric("retry_warnings_total", "Total of retry warnings.", nil),
+		16: newBackendMetric("redispatch_warnings_total", "Total of redispatch warnings.", nil),
+		17: newBackendMetric("up", "Current health status of the backend (1 = UP, 0 = DOWN).", nil),
+		18: newBackendMetric("weight", "Total weight of the servers in the backend.", nil),
+		19: newBackendMetric("current_server", "Current number of active servers", nil),
+		33: newBackendMetric("current_session_rate", "Current number of sessions per second over last elapsed second.", nil),
+		35: newBackendMetric("max_session_rate", "Maximum number of sessions per second.", nil),
+		39: newBackendMetric("http_responses_total", "Total of HTTP responses.", prometheus.Labels{"code": "1xx"}),
+		40: newBackendMetric("http_responses_total", "Total of HTTP responses.", prometheus.Labels{"code": "2xx"}),
+		41: newBackendMetric("http_responses_total", "Total of HTTP responses.", prometheus.Labels{"code": "3xx"}),
+		42: newBackendMetric("http_responses_total", "Total of HTTP responses.", prometheus.Labels{"code": "4xx"}),
+		43: newBackendMetric("http_responses_total", "Total of HTTP responses.", prometheus.Labels{"code": "5xx"}),
+		44: newBackendMetric("http_responses_total", "Total of HTTP responses.", prometheus.Labels{"code": "other"}),
+		58: newBackendMetric("http_queue_time_average_seconds", "Avg. HTTP queue time for last 1024 successful connections.", nil),
+		59: newBackendMetric("http_connect_time_average_seconds", "Avg. HTTP connect time for last 1024 successful connections.", nil),
+		60: newBackendMetric("http_response_time_average_seconds", "Avg. HTTP response time for last 1024 successful connections.", nil),
+		61: newBackendMetric("http_total_time_average_seconds", "Avg. HTTP total time for last 1024 successful connections.", nil),
+	}
+
+	haproxyUp = prometheus.NewDesc(prometheus.BuildFQName(namespace, "", "up"), "Was the last scrape of haproxy successful.", nil, nil)
 )
 
 // Exporter collects HAProxy stats from the given URI and exports them using
@@ -150,13 +179,13 @@ type Exporter struct {
 	mutex sync.RWMutex
 	fetch func() (io.ReadCloser, error)
 
-	up                                             prometheus.Gauge
-	totalScrapes, csvParseFailures                 prometheus.Counter
-	frontendMetrics, backendMetrics, serverMetrics map[int]*prometheus.GaugeVec
+	up                             prometheus.Gauge
+	totalScrapes, csvParseFailures prometheus.Counter
+	serverMetrics                  map[int]*prometheus.Desc
 }
 
 // NewExporter returns an initialized Exporter.
-func NewExporter(uri string, sslVerify bool, selectedServerMetrics map[int]*prometheus.GaugeVec, timeout time.Duration) (*Exporter, error) {
+func NewExporter(uri string, sslVerify bool, selectedServerMetrics map[int]*prometheus.Desc, timeout time.Duration) (*Exporter, error) {
 	u, err := url.Parse(uri)
 	if err != nil {
 		return nil, err
@@ -190,56 +219,6 @@ func NewExporter(uri string, sslVerify bool, selectedServerMetrics map[int]*prom
 			Name:      "exporter_csv_parse_failures",
 			Help:      "Number of errors while parsing CSV.",
 		}),
-		frontendMetrics: map[int]*prometheus.GaugeVec{
-			4:  newFrontendMetric("current_sessions", "Current number of active sessions.", nil),
-			5:  newFrontendMetric("max_sessions", "Maximum observed number of active sessions.", nil),
-			6:  newFrontendMetric("limit_sessions", "Configured session limit.", nil),
-			7:  newFrontendMetric("sessions_total", "Total number of sessions.", nil),
-			8:  newFrontendMetric("bytes_in_total", "Current total of incoming bytes.", nil),
-			9:  newFrontendMetric("bytes_out_total", "Current total of outgoing bytes.", nil),
-			10: newFrontendMetric("requests_denied_total", "Total of requests denied for security.", nil),
-			12: newFrontendMetric("request_errors_total", "Total of request errors.", nil),
-			33: newFrontendMetric("current_session_rate", "Current number of sessions per second over last elapsed second.", nil),
-			34: newFrontendMetric("limit_session_rate", "Configured limit on new sessions per second.", nil),
-			35: newFrontendMetric("max_session_rate", "Maximum observed number of sessions per second.", nil),
-			39: newFrontendMetric("http_responses_total", "Total of HTTP responses.", prometheus.Labels{"code": "1xx"}),
-			40: newFrontendMetric("http_responses_total", "Total of HTTP responses.", prometheus.Labels{"code": "2xx"}),
-			41: newFrontendMetric("http_responses_total", "Total of HTTP responses.", prometheus.Labels{"code": "3xx"}),
-			42: newFrontendMetric("http_responses_total", "Total of HTTP responses.", prometheus.Labels{"code": "4xx"}),
-			43: newFrontendMetric("http_responses_total", "Total of HTTP responses.", prometheus.Labels{"code": "5xx"}),
-			44: newFrontendMetric("http_responses_total", "Total of HTTP responses.", prometheus.Labels{"code": "other"}),
-			48: newFrontendMetric("http_requests_total", "Total HTTP requests.", nil),
-			79: newFrontendMetric("connections_total", "Total number of connections", nil),
-		},
-		backendMetrics: map[int]*prometheus.GaugeVec{
-			2:  newBackendMetric("current_queue", "Current number of queued requests not assigned to any server.", nil),
-			3:  newBackendMetric("max_queue", "Maximum observed number of queued requests not assigned to any server.", nil),
-			4:  newBackendMetric("current_sessions", "Current number of active sessions.", nil),
-			5:  newBackendMetric("max_sessions", "Maximum observed number of active sessions.", nil),
-			6:  newBackendMetric("limit_sessions", "Configured session limit.", nil),
-			7:  newBackendMetric("sessions_total", "Total number of sessions.", nil),
-			8:  newBackendMetric("bytes_in_total", "Current total of incoming bytes.", nil),
-			9:  newBackendMetric("bytes_out_total", "Current total of outgoing bytes.", nil),
-			13: newBackendMetric("connection_errors_total", "Total of connection errors.", nil),
-			14: newBackendMetric("response_errors_total", "Total of response errors.", nil),
-			15: newBackendMetric("retry_warnings_total", "Total of retry warnings.", nil),
-			16: newBackendMetric("redispatch_warnings_total", "Total of redispatch warnings.", nil),
-			17: newBackendMetric("up", "Current health status of the backend (1 = UP, 0 = DOWN).", nil),
-			18: newBackendMetric("weight", "Total weight of the servers in the backend.", nil),
-			19: newBackendMetric("current_server", "Current number of active servers", nil),
-			33: newBackendMetric("current_session_rate", "Current number of sessions per second over last elapsed second.", nil),
-			35: newBackendMetric("max_session_rate", "Maximum number of sessions per second.", nil),
-			39: newBackendMetric("http_responses_total", "Total of HTTP responses.", prometheus.Labels{"code": "1xx"}),
-			40: newBackendMetric("http_responses_total", "Total of HTTP responses.", prometheus.Labels{"code": "2xx"}),
-			41: newBackendMetric("http_responses_total", "Total of HTTP responses.", prometheus.Labels{"code": "3xx"}),
-			42: newBackendMetric("http_responses_total", "Total of HTTP responses.", prometheus.Labels{"code": "4xx"}),
-			43: newBackendMetric("http_responses_total", "Total of HTTP responses.", prometheus.Labels{"code": "5xx"}),
-			44: newBackendMetric("http_responses_total", "Total of HTTP responses.", prometheus.Labels{"code": "other"}),
-			58: newBackendMetric("http_queue_time_average_seconds", "Avg. HTTP queue time for last 1024 successful connections.", nil),
-			59: newBackendMetric("http_connect_time_average_seconds", "Avg. HTTP connect time for last 1024 successful connections.", nil),
-			60: newBackendMetric("http_response_time_average_seconds", "Avg. HTTP response time for last 1024 successful connections.", nil),
-			61: newBackendMetric("http_total_time_average_seconds", "Avg. HTTP total time for last 1024 successful connections.", nil),
-		},
 		serverMetrics: selectedServerMetrics,
 	}, nil
 }
@@ -247,16 +226,16 @@ func NewExporter(uri string, sslVerify bool, selectedServerMetrics map[int]*prom
 // Describe describes all the metrics ever exported by the HAProxy exporter. It
 // implements prometheus.Collector.
 func (e *Exporter) Describe(ch chan<- *prometheus.Desc) {
-	for _, m := range e.frontendMetrics {
-		m.Describe(ch)
+	for _, m := range frontendMetrics {
+		ch <- m
 	}
-	for _, m := range e.backendMetrics {
-		m.Describe(ch)
+	for _, m := range backendMetrics {
+		ch <- m
 	}
 	for _, m := range e.serverMetrics {
-		m.Describe(ch)
+		ch <- m
 	}
-	ch <- e.up.Desc()
+	ch <- haproxyUp
 	ch <- e.totalScrapes.Desc()
 	ch <- e.csvParseFailures.Desc()
 }
@@ -267,13 +246,11 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 	e.mutex.Lock() // To protect metrics from concurrent collects.
 	defer e.mutex.Unlock()
 
-	e.resetMetrics()
-	e.scrape()
+	up := e.scrape(ch)
 
-	ch <- e.up
+	ch <- prometheus.MustNewConstMetric(haproxyUp, prometheus.GaugeValue, up)
 	ch <- e.totalScrapes
 	ch <- e.csvParseFailures
-	e.collectMetrics(ch)
 }
 
 func fetchHTTP(uri string, sslVerify bool, timeout time.Duration) func() (io.ReadCloser, error) {
@@ -320,17 +297,15 @@ func fetchUnix(u *url.URL, timeout time.Duration) func() (io.ReadCloser, error) 
 	}
 }
 
-func (e *Exporter) scrape() {
+func (e *Exporter) scrape(ch chan<- prometheus.Metric) (up float64) {
 	e.totalScrapes.Inc()
 
 	body, err := e.fetch()
 	if err != nil {
-		e.up.Set(0)
 		log.Errorf("Can't scrape HAProxy: %v", err)
-		return
+		return 0
 	}
 	defer body.Close()
-	e.up.Set(1)
 
 	reader := csv.NewReader(body)
 	reader.TrailingComma = true
@@ -350,38 +325,14 @@ loop:
 				continue loop
 			}
 			log.Errorf("Unexpected error while reading CSV: %v", err)
-			e.up.Set(0)
-			break loop
+			return 0
 		}
-		e.parseRow(row)
+		e.parseRow(row, ch)
 	}
+	return 1
 }
 
-func (e *Exporter) resetMetrics() {
-	for _, m := range e.frontendMetrics {
-		m.Reset()
-	}
-	for _, m := range e.backendMetrics {
-		m.Reset()
-	}
-	for _, m := range e.serverMetrics {
-		m.Reset()
-	}
-}
-
-func (e *Exporter) collectMetrics(metrics chan<- prometheus.Metric) {
-	for _, m := range e.frontendMetrics {
-		m.Collect(metrics)
-	}
-	for _, m := range e.backendMetrics {
-		m.Collect(metrics)
-	}
-	for _, m := range e.serverMetrics {
-		m.Collect(metrics)
-	}
-}
-
-func (e *Exporter) parseRow(csvRow []string) {
+func (e *Exporter) parseRow(csvRow []string, ch chan<- prometheus.Metric) {
 	if len(csvRow) < minimumCsvFieldCount {
 		log.Errorf("Parser expected at least %d CSV fields, but got: %d", minimumCsvFieldCount, len(csvRow))
 		e.csvParseFailures.Inc()
@@ -398,11 +349,11 @@ func (e *Exporter) parseRow(csvRow []string) {
 
 	switch typ {
 	case frontend:
-		e.exportCsvFields(e.frontendMetrics, csvRow, pxname)
+		e.exportCsvFields(frontendMetrics, csvRow, ch, pxname)
 	case backend:
-		e.exportCsvFields(e.backendMetrics, csvRow, pxname)
+		e.exportCsvFields(backendMetrics, csvRow, ch, pxname)
 	case server:
-		e.exportCsvFields(e.serverMetrics, csvRow, pxname, svname)
+		e.exportCsvFields(e.serverMetrics, csvRow, ch, pxname, svname)
 	}
 }
 
@@ -416,10 +367,11 @@ func parseStatusField(value string) int64 {
 	return 0
 }
 
-func (e *Exporter) exportCsvFields(metrics map[int]*prometheus.GaugeVec, csvRow []string, labels ...string) {
+func (e *Exporter) exportCsvFields(metrics map[int]*prometheus.Desc, csvRow []string, ch chan<- prometheus.Metric, labels ...string) {
 	for fieldIdx, metric := range metrics {
 		if fieldIdx > len(csvRow)-1 {
-			break
+			// We can't break here because we are not looping over the fields in sorted order.
+			continue
 		}
 		valueStr := csvRow[fieldIdx]
 		if valueStr == "" {
@@ -446,14 +398,14 @@ func (e *Exporter) exportCsvFields(metrics map[int]*prometheus.GaugeVec, csvRow 
 			e.csvParseFailures.Inc()
 			continue
 		}
-		metric.WithLabelValues(labels...).Set(value)
+		ch <- prometheus.MustNewConstMetric(metric, prometheus.GaugeValue, value, labels...)
 	}
 }
 
 // filterServerMetrics returns the set of server metrics specified by the comma
 // separated filter.
-func filterServerMetrics(filter string) (map[int]*prometheus.GaugeVec, error) {
-	metrics := map[int]*prometheus.GaugeVec{}
+func filterServerMetrics(filter string) (map[int]*prometheus.Desc, error) {
+	metrics := map[int]*prometheus.Desc{}
 	if len(filter) == 0 {
 		return metrics, nil
 	}

--- a/test/deadline.metrics
+++ b/test/deadline.metrics
@@ -1,0 +1,9 @@
+# HELP haproxy_exporter_csv_parse_failures Number of errors while parsing CSV.
+# TYPE haproxy_exporter_csv_parse_failures counter
+haproxy_exporter_csv_parse_failures 0
+# HELP haproxy_exporter_total_scrapes Current total HAProxy scrapes.
+# TYPE haproxy_exporter_total_scrapes counter
+haproxy_exporter_total_scrapes 1
+# HELP haproxy_up Was the last scrape of haproxy successful.
+# TYPE haproxy_up gauge
+haproxy_up 0

--- a/test/invalid_config.metrics
+++ b/test/invalid_config.metrics
@@ -1,0 +1,9 @@
+# HELP haproxy_exporter_csv_parse_failures Number of errors while parsing CSV.
+# TYPE haproxy_exporter_csv_parse_failures counter
+haproxy_exporter_csv_parse_failures 1
+# HELP haproxy_exporter_total_scrapes Current total HAProxy scrapes.
+# TYPE haproxy_exporter_total_scrapes counter
+haproxy_exporter_total_scrapes 1
+# HELP haproxy_up Was the last scrape of haproxy successful.
+# TYPE haproxy_up gauge
+haproxy_up 1

--- a/test/not_found.metrics
+++ b/test/not_found.metrics
@@ -1,0 +1,9 @@
+# HELP haproxy_exporter_csv_parse_failures Number of errors while parsing CSV.
+# TYPE haproxy_exporter_csv_parse_failures counter
+haproxy_exporter_csv_parse_failures 0
+# HELP haproxy_exporter_total_scrapes Current total HAProxy scrapes.
+# TYPE haproxy_exporter_total_scrapes counter
+haproxy_exporter_total_scrapes 1
+# HELP haproxy_up Was the last scrape of haproxy successful.
+# TYPE haproxy_up gauge
+haproxy_up 0

--- a/test/older_haproxy_versions.metrics
+++ b/test/older_haproxy_versions.metrics
@@ -1,0 +1,84 @@
+# HELP haproxy_exporter_csv_parse_failures Number of errors while parsing CSV.
+# TYPE haproxy_exporter_csv_parse_failures counter
+haproxy_exporter_csv_parse_failures 0
+# HELP haproxy_exporter_total_scrapes Current total HAProxy scrapes.
+# TYPE haproxy_exporter_total_scrapes counter
+haproxy_exporter_total_scrapes 1
+# HELP haproxy_server_bytes_in_total Current total of incoming bytes.
+# TYPE haproxy_server_bytes_in_total gauge
+haproxy_server_bytes_in_total{backend="foo",server="BACKEND"} 0
+haproxy_server_bytes_in_total{backend="foo",server="FRONTEND"} 0
+haproxy_server_bytes_in_total{backend="foo",server="foo-instance-0"} 0
+# HELP haproxy_server_bytes_out_total Current total of outgoing bytes.
+# TYPE haproxy_server_bytes_out_total gauge
+haproxy_server_bytes_out_total{backend="foo",server="BACKEND"} 0
+haproxy_server_bytes_out_total{backend="foo",server="FRONTEND"} 0
+haproxy_server_bytes_out_total{backend="foo",server="foo-instance-0"} 0
+# HELP haproxy_server_check_failures_total Total number of failed health checks.
+# TYPE haproxy_server_check_failures_total gauge
+haproxy_server_check_failures_total{backend="foo",server="BACKEND"} 0
+haproxy_server_check_failures_total{backend="foo",server="FRONTEND"} 0
+haproxy_server_check_failures_total{backend="foo",server="foo-instance-0"} 0
+# HELP haproxy_server_connection_errors_total Total of connection errors.
+# TYPE haproxy_server_connection_errors_total gauge
+haproxy_server_connection_errors_total{backend="foo",server="BACKEND"} 0
+haproxy_server_connection_errors_total{backend="foo",server="FRONTEND"} 0
+haproxy_server_connection_errors_total{backend="foo",server="foo-instance-0"} 0
+# HELP haproxy_server_current_queue Current number of queued requests assigned to this server.
+# TYPE haproxy_server_current_queue gauge
+haproxy_server_current_queue{backend="foo",server="BACKEND"} 0
+haproxy_server_current_queue{backend="foo",server="FRONTEND"} 0
+haproxy_server_current_queue{backend="foo",server="foo-instance-0"} 0
+# HELP haproxy_server_current_sessions Current number of active sessions.
+# TYPE haproxy_server_current_sessions gauge
+haproxy_server_current_sessions{backend="foo",server="BACKEND"} 0
+haproxy_server_current_sessions{backend="foo",server="FRONTEND"} 0
+haproxy_server_current_sessions{backend="foo",server="foo-instance-0"} 0
+# HELP haproxy_server_downtime_seconds_total Total downtime in seconds.
+# TYPE haproxy_server_downtime_seconds_total gauge
+haproxy_server_downtime_seconds_total{backend="foo",server="BACKEND"} 0
+haproxy_server_downtime_seconds_total{backend="foo",server="FRONTEND"} 0
+haproxy_server_downtime_seconds_total{backend="foo",server="foo-instance-0"} 0
+# HELP haproxy_server_max_queue Maximum observed number of queued requests assigned to this server.
+# TYPE haproxy_server_max_queue gauge
+haproxy_server_max_queue{backend="foo",server="BACKEND"} 0
+haproxy_server_max_queue{backend="foo",server="FRONTEND"} 0
+haproxy_server_max_queue{backend="foo",server="foo-instance-0"} 0
+# HELP haproxy_server_max_sessions Maximum observed number of active sessions.
+# TYPE haproxy_server_max_sessions gauge
+haproxy_server_max_sessions{backend="foo",server="BACKEND"} 0
+haproxy_server_max_sessions{backend="foo",server="FRONTEND"} 0
+haproxy_server_max_sessions{backend="foo",server="foo-instance-0"} 0
+# HELP haproxy_server_redispatch_warnings_total Total of redispatch warnings.
+# TYPE haproxy_server_redispatch_warnings_total gauge
+haproxy_server_redispatch_warnings_total{backend="foo",server="BACKEND"} 0
+haproxy_server_redispatch_warnings_total{backend="foo",server="FRONTEND"} 0
+haproxy_server_redispatch_warnings_total{backend="foo",server="foo-instance-0"} 0
+# HELP haproxy_server_response_errors_total Total of response errors.
+# TYPE haproxy_server_response_errors_total gauge
+haproxy_server_response_errors_total{backend="foo",server="BACKEND"} 0
+haproxy_server_response_errors_total{backend="foo",server="FRONTEND"} 0
+haproxy_server_response_errors_total{backend="foo",server="foo-instance-0"} 0
+# HELP haproxy_server_retry_warnings_total Total of retry warnings.
+# TYPE haproxy_server_retry_warnings_total gauge
+haproxy_server_retry_warnings_total{backend="foo",server="BACKEND"} 0
+haproxy_server_retry_warnings_total{backend="foo",server="FRONTEND"} 0
+haproxy_server_retry_warnings_total{backend="foo",server="foo-instance-0"} 0
+# HELP haproxy_server_sessions_total Total number of sessions.
+# TYPE haproxy_server_sessions_total gauge
+haproxy_server_sessions_total{backend="foo",server="BACKEND"} 0
+haproxy_server_sessions_total{backend="foo",server="FRONTEND"} 0
+haproxy_server_sessions_total{backend="foo",server="foo-instance-0"} 0
+# HELP haproxy_server_up Current health status of the server (1 = UP, 0 = DOWN).
+# TYPE haproxy_server_up gauge
+haproxy_server_up{backend="foo",server="BACKEND"} 1
+haproxy_server_up{backend="foo",server="FRONTEND"} 1
+haproxy_server_up{backend="foo",server="foo-instance-0"} 1
+# HELP haproxy_server_weight Current weight of the server.
+# TYPE haproxy_server_weight gauge
+haproxy_server_weight{backend="foo",server="BACKEND"} 1
+haproxy_server_weight{backend="foo",server="FRONTEND"} 1
+haproxy_server_weight{backend="foo",server="foo-instance-0"} 1
+# HELP haproxy_up Was the last scrape of haproxy successful.
+# TYPE haproxy_up gauge
+haproxy_up 1

--- a/test/server_broken_csv.metrics
+++ b/test/server_broken_csv.metrics
@@ -1,0 +1,99 @@
+# HELP haproxy_exporter_csv_parse_failures Number of errors while parsing CSV.
+# TYPE haproxy_exporter_csv_parse_failures counter
+haproxy_exporter_csv_parse_failures 1
+# HELP haproxy_exporter_total_scrapes Current total HAProxy scrapes.
+# TYPE haproxy_exporter_total_scrapes counter
+haproxy_exporter_total_scrapes 1
+# HELP haproxy_server_bytes_in_total Current total of incoming bytes.
+# TYPE haproxy_server_bytes_in_total gauge
+haproxy_server_bytes_in_total{backend="foo",server="BACKEND"} 0
+haproxy_server_bytes_in_total{backend="foo",server="FRONTEND"} 0
+haproxy_server_bytes_in_total{backend="foo",server="foo-instance-0"} 0
+# HELP haproxy_server_bytes_out_total Current total of outgoing bytes.
+# TYPE haproxy_server_bytes_out_total gauge
+haproxy_server_bytes_out_total{backend="foo",server="BACKEND"} 0
+haproxy_server_bytes_out_total{backend="foo",server="FRONTEND"} 0
+haproxy_server_bytes_out_total{backend="foo",server="foo-instance-0"} 0
+# HELP haproxy_server_check_duration_milliseconds Previously run health check duration, in milliseconds
+# TYPE haproxy_server_check_duration_milliseconds gauge
+haproxy_server_check_duration_milliseconds{backend="foo",server="BACKEND"} 0
+haproxy_server_check_duration_milliseconds{backend="foo",server="FRONTEND"} 0
+haproxy_server_check_duration_milliseconds{backend="foo",server="foo-instance-0"} 0
+# HELP haproxy_server_check_failures_total Total number of failed health checks.
+# TYPE haproxy_server_check_failures_total gauge
+haproxy_server_check_failures_total{backend="foo",server="BACKEND"} 0
+haproxy_server_check_failures_total{backend="foo",server="FRONTEND"} 0
+haproxy_server_check_failures_total{backend="foo",server="foo-instance-0"} 0
+# HELP haproxy_server_connection_errors_total Total of connection errors.
+# TYPE haproxy_server_connection_errors_total gauge
+haproxy_server_connection_errors_total{backend="foo",server="BACKEND"} 0
+haproxy_server_connection_errors_total{backend="foo",server="FRONTEND"} 0
+haproxy_server_connection_errors_total{backend="foo",server="foo-instance-0"} 0
+# HELP haproxy_server_current_queue Current number of queued requests assigned to this server.
+# TYPE haproxy_server_current_queue gauge
+haproxy_server_current_queue{backend="foo",server="BACKEND"} 0
+haproxy_server_current_queue{backend="foo",server="FRONTEND"} 0
+haproxy_server_current_queue{backend="foo",server="foo-instance-0"} 0
+# HELP haproxy_server_current_session_rate Current number of sessions per second over last elapsed second.
+# TYPE haproxy_server_current_session_rate gauge
+haproxy_server_current_session_rate{backend="foo",server="BACKEND"} 0
+haproxy_server_current_session_rate{backend="foo",server="FRONTEND"} 0
+haproxy_server_current_session_rate{backend="foo",server="foo-instance-0"} 0
+# HELP haproxy_server_current_sessions Current number of active sessions.
+# TYPE haproxy_server_current_sessions gauge
+haproxy_server_current_sessions{backend="foo",server="BACKEND"} 0
+haproxy_server_current_sessions{backend="foo",server="FRONTEND"} 0
+haproxy_server_current_sessions{backend="foo",server="foo-instance-0"} 0
+# HELP haproxy_server_downtime_seconds_total Total downtime in seconds.
+# TYPE haproxy_server_downtime_seconds_total gauge
+haproxy_server_downtime_seconds_total{backend="foo",server="BACKEND"} 0
+haproxy_server_downtime_seconds_total{backend="foo",server="FRONTEND"} 0
+haproxy_server_downtime_seconds_total{backend="foo",server="foo-instance-0"} 0
+# HELP haproxy_server_max_queue Maximum observed number of queued requests assigned to this server.
+# TYPE haproxy_server_max_queue gauge
+haproxy_server_max_queue{backend="foo",server="BACKEND"} 0
+haproxy_server_max_queue{backend="foo",server="FRONTEND"} 0
+haproxy_server_max_queue{backend="foo",server="foo-instance-0"} 0
+# HELP haproxy_server_max_session_rate Maximum observed number of sessions per second.
+# TYPE haproxy_server_max_session_rate gauge
+haproxy_server_max_session_rate{backend="foo",server="BACKEND"} 0
+haproxy_server_max_session_rate{backend="foo",server="FRONTEND"} 0
+haproxy_server_max_session_rate{backend="foo",server="foo-instance-0"} 0
+# HELP haproxy_server_max_sessions Maximum observed number of active sessions.
+# TYPE haproxy_server_max_sessions gauge
+haproxy_server_max_sessions{backend="foo",server="BACKEND"} 0
+haproxy_server_max_sessions{backend="foo",server="FRONTEND"} 0
+haproxy_server_max_sessions{backend="foo",server="foo-instance-0"} 0
+# HELP haproxy_server_redispatch_warnings_total Total of redispatch warnings.
+# TYPE haproxy_server_redispatch_warnings_total gauge
+haproxy_server_redispatch_warnings_total{backend="foo",server="BACKEND"} 0
+haproxy_server_redispatch_warnings_total{backend="foo",server="FRONTEND"} 0
+haproxy_server_redispatch_warnings_total{backend="foo",server="foo-instance-0"} 0
+# HELP haproxy_server_response_errors_total Total of response errors.
+# TYPE haproxy_server_response_errors_total gauge
+haproxy_server_response_errors_total{backend="foo",server="BACKEND"} 0
+haproxy_server_response_errors_total{backend="foo",server="FRONTEND"} 0
+haproxy_server_response_errors_total{backend="foo",server="foo-instance-0"} 0
+# HELP haproxy_server_retry_warnings_total Total of retry warnings.
+# TYPE haproxy_server_retry_warnings_total gauge
+haproxy_server_retry_warnings_total{backend="foo",server="BACKEND"} 0
+haproxy_server_retry_warnings_total{backend="foo",server="FRONTEND"} 0
+haproxy_server_retry_warnings_total{backend="foo",server="foo-instance-0"} 0
+# HELP haproxy_server_sessions_total Total number of sessions.
+# TYPE haproxy_server_sessions_total gauge
+haproxy_server_sessions_total{backend="foo",server="BACKEND"} 0
+haproxy_server_sessions_total{backend="foo",server="FRONTEND"} 0
+haproxy_server_sessions_total{backend="foo",server="foo-instance-0"} 0
+# HELP haproxy_server_up Current health status of the server (1 = UP, 0 = DOWN).
+# TYPE haproxy_server_up gauge
+haproxy_server_up{backend="foo",server="BACKEND"} 1
+haproxy_server_up{backend="foo",server="FRONTEND"} 1
+haproxy_server_up{backend="foo",server="foo-instance-0"} 1
+# HELP haproxy_server_weight Current weight of the server.
+# TYPE haproxy_server_weight gauge
+haproxy_server_weight{backend="foo",server="BACKEND"} 1
+haproxy_server_weight{backend="foo",server="FRONTEND"} 1
+haproxy_server_weight{backend="foo",server="foo-instance-0"} 1
+# HELP haproxy_up Was the last scrape of haproxy successful.
+# TYPE haproxy_up gauge
+haproxy_up 1

--- a/test/server_without_checks.metrics
+++ b/test/server_without_checks.metrics
@@ -1,0 +1,71 @@
+# HELP haproxy_exporter_csv_parse_failures Number of errors while parsing CSV.
+# TYPE haproxy_exporter_csv_parse_failures counter
+haproxy_exporter_csv_parse_failures 0
+# HELP haproxy_exporter_total_scrapes Current total HAProxy scrapes.
+# TYPE haproxy_exporter_total_scrapes counter
+haproxy_exporter_total_scrapes 1
+# HELP haproxy_server_bytes_in_total Current total of incoming bytes.
+# TYPE haproxy_server_bytes_in_total gauge
+haproxy_server_bytes_in_total{backend="test",server="127.0.0.1:8080"} 0
+# HELP haproxy_server_bytes_out_total Current total of outgoing bytes.
+# TYPE haproxy_server_bytes_out_total gauge
+haproxy_server_bytes_out_total{backend="test",server="127.0.0.1:8080"} 0
+# HELP haproxy_server_check_failures_total Total number of failed health checks.
+# TYPE haproxy_server_check_failures_total gauge
+haproxy_server_check_failures_total{backend="test",server="127.0.0.1:8080"} 0
+# HELP haproxy_server_connection_errors_total Total of connection errors.
+# TYPE haproxy_server_connection_errors_total gauge
+haproxy_server_connection_errors_total{backend="test",server="127.0.0.1:8080"} 0
+# HELP haproxy_server_current_queue Current number of queued requests assigned to this server.
+# TYPE haproxy_server_current_queue gauge
+haproxy_server_current_queue{backend="test",server="127.0.0.1:8080"} 0
+# HELP haproxy_server_current_session_rate Current number of sessions per second over last elapsed second.
+# TYPE haproxy_server_current_session_rate gauge
+haproxy_server_current_session_rate{backend="test",server="127.0.0.1:8080"} 0
+# HELP haproxy_server_current_sessions Current number of active sessions.
+# TYPE haproxy_server_current_sessions gauge
+haproxy_server_current_sessions{backend="test",server="127.0.0.1:8080"} 0
+# HELP haproxy_server_downtime_seconds_total Total downtime in seconds.
+# TYPE haproxy_server_downtime_seconds_total gauge
+haproxy_server_downtime_seconds_total{backend="test",server="127.0.0.1:8080"} 0
+# HELP haproxy_server_http_responses_total Total of HTTP responses.
+# TYPE haproxy_server_http_responses_total gauge
+haproxy_server_http_responses_total{backend="test",code="1xx",server="127.0.0.1:8080"} 0
+haproxy_server_http_responses_total{backend="test",code="2xx",server="127.0.0.1:8080"} 0
+haproxy_server_http_responses_total{backend="test",code="3xx",server="127.0.0.1:8080"} 0
+haproxy_server_http_responses_total{backend="test",code="4xx",server="127.0.0.1:8080"} 0
+haproxy_server_http_responses_total{backend="test",code="5xx",server="127.0.0.1:8080"} 0
+haproxy_server_http_responses_total{backend="test",code="other",server="127.0.0.1:8080"} 0
+# HELP haproxy_server_limit_sessions Configured session limit.
+# TYPE haproxy_server_limit_sessions gauge
+haproxy_server_limit_sessions{backend="test",server="127.0.0.1:8080"} 0
+# HELP haproxy_server_max_queue Maximum observed number of queued requests assigned to this server.
+# TYPE haproxy_server_max_queue gauge
+haproxy_server_max_queue{backend="test",server="127.0.0.1:8080"} 0
+# HELP haproxy_server_max_session_rate Maximum observed number of sessions per second.
+# TYPE haproxy_server_max_session_rate gauge
+haproxy_server_max_session_rate{backend="test",server="127.0.0.1:8080"} 0
+# HELP haproxy_server_max_sessions Maximum observed number of active sessions.
+# TYPE haproxy_server_max_sessions gauge
+haproxy_server_max_sessions{backend="test",server="127.0.0.1:8080"} 0
+# HELP haproxy_server_redispatch_warnings_total Total of redispatch warnings.
+# TYPE haproxy_server_redispatch_warnings_total gauge
+haproxy_server_redispatch_warnings_total{backend="test",server="127.0.0.1:8080"} 0
+# HELP haproxy_server_response_errors_total Total of response errors.
+# TYPE haproxy_server_response_errors_total gauge
+haproxy_server_response_errors_total{backend="test",server="127.0.0.1:8080"} 0
+# HELP haproxy_server_retry_warnings_total Total of retry warnings.
+# TYPE haproxy_server_retry_warnings_total gauge
+haproxy_server_retry_warnings_total{backend="test",server="127.0.0.1:8080"} 0
+# HELP haproxy_server_sessions_total Total number of sessions.
+# TYPE haproxy_server_sessions_total gauge
+haproxy_server_sessions_total{backend="test",server="127.0.0.1:8080"} 0
+# HELP haproxy_server_up Current health status of the server (1 = UP, 0 = DOWN).
+# TYPE haproxy_server_up gauge
+haproxy_server_up{backend="test",server="127.0.0.1:8080"} 1
+# HELP haproxy_server_weight Current weight of the server.
+# TYPE haproxy_server_weight gauge
+haproxy_server_weight{backend="test",server="127.0.0.1:8080"} 1
+# HELP haproxy_up Was the last scrape of haproxy successful.
+# TYPE haproxy_up gauge
+haproxy_up 1

--- a/test/unix_domain.metrics
+++ b/test/unix_domain.metrics
@@ -1,0 +1,71 @@
+# HELP haproxy_exporter_csv_parse_failures Number of errors while parsing CSV.
+# TYPE haproxy_exporter_csv_parse_failures counter
+haproxy_exporter_csv_parse_failures 0
+# HELP haproxy_exporter_total_scrapes Current total HAProxy scrapes.
+# TYPE haproxy_exporter_total_scrapes counter
+haproxy_exporter_total_scrapes 1
+# HELP haproxy_server_bytes_in_total Current total of incoming bytes.
+# TYPE haproxy_server_bytes_in_total gauge
+haproxy_server_bytes_in_total{backend="test",server="127.0.0.1:8080"} 0
+# HELP haproxy_server_bytes_out_total Current total of outgoing bytes.
+# TYPE haproxy_server_bytes_out_total gauge
+haproxy_server_bytes_out_total{backend="test",server="127.0.0.1:8080"} 0
+# HELP haproxy_server_check_failures_total Total number of failed health checks.
+# TYPE haproxy_server_check_failures_total gauge
+haproxy_server_check_failures_total{backend="test",server="127.0.0.1:8080"} 0
+# HELP haproxy_server_connection_errors_total Total of connection errors.
+# TYPE haproxy_server_connection_errors_total gauge
+haproxy_server_connection_errors_total{backend="test",server="127.0.0.1:8080"} 0
+# HELP haproxy_server_current_queue Current number of queued requests assigned to this server.
+# TYPE haproxy_server_current_queue gauge
+haproxy_server_current_queue{backend="test",server="127.0.0.1:8080"} 0
+# HELP haproxy_server_current_session_rate Current number of sessions per second over last elapsed second.
+# TYPE haproxy_server_current_session_rate gauge
+haproxy_server_current_session_rate{backend="test",server="127.0.0.1:8080"} 0
+# HELP haproxy_server_current_sessions Current number of active sessions.
+# TYPE haproxy_server_current_sessions gauge
+haproxy_server_current_sessions{backend="test",server="127.0.0.1:8080"} 0
+# HELP haproxy_server_downtime_seconds_total Total downtime in seconds.
+# TYPE haproxy_server_downtime_seconds_total gauge
+haproxy_server_downtime_seconds_total{backend="test",server="127.0.0.1:8080"} 0
+# HELP haproxy_server_http_responses_total Total of HTTP responses.
+# TYPE haproxy_server_http_responses_total gauge
+haproxy_server_http_responses_total{backend="test",code="1xx",server="127.0.0.1:8080"} 0
+haproxy_server_http_responses_total{backend="test",code="2xx",server="127.0.0.1:8080"} 0
+haproxy_server_http_responses_total{backend="test",code="3xx",server="127.0.0.1:8080"} 0
+haproxy_server_http_responses_total{backend="test",code="4xx",server="127.0.0.1:8080"} 0
+haproxy_server_http_responses_total{backend="test",code="5xx",server="127.0.0.1:8080"} 0
+haproxy_server_http_responses_total{backend="test",code="other",server="127.0.0.1:8080"} 0
+# HELP haproxy_server_limit_sessions Configured session limit.
+# TYPE haproxy_server_limit_sessions gauge
+haproxy_server_limit_sessions{backend="test",server="127.0.0.1:8080"} 0
+# HELP haproxy_server_max_queue Maximum observed number of queued requests assigned to this server.
+# TYPE haproxy_server_max_queue gauge
+haproxy_server_max_queue{backend="test",server="127.0.0.1:8080"} 0
+# HELP haproxy_server_max_session_rate Maximum observed number of sessions per second.
+# TYPE haproxy_server_max_session_rate gauge
+haproxy_server_max_session_rate{backend="test",server="127.0.0.1:8080"} 0
+# HELP haproxy_server_max_sessions Maximum observed number of active sessions.
+# TYPE haproxy_server_max_sessions gauge
+haproxy_server_max_sessions{backend="test",server="127.0.0.1:8080"} 0
+# HELP haproxy_server_redispatch_warnings_total Total of redispatch warnings.
+# TYPE haproxy_server_redispatch_warnings_total gauge
+haproxy_server_redispatch_warnings_total{backend="test",server="127.0.0.1:8080"} 0
+# HELP haproxy_server_response_errors_total Total of response errors.
+# TYPE haproxy_server_response_errors_total gauge
+haproxy_server_response_errors_total{backend="test",server="127.0.0.1:8080"} 0
+# HELP haproxy_server_retry_warnings_total Total of retry warnings.
+# TYPE haproxy_server_retry_warnings_total gauge
+haproxy_server_retry_warnings_total{backend="test",server="127.0.0.1:8080"} 0
+# HELP haproxy_server_sessions_total Total number of sessions.
+# TYPE haproxy_server_sessions_total gauge
+haproxy_server_sessions_total{backend="test",server="127.0.0.1:8080"} 0
+# HELP haproxy_server_up Current health status of the server (1 = UP, 0 = DOWN).
+# TYPE haproxy_server_up gauge
+haproxy_server_up{backend="test",server="127.0.0.1:8080"} 1
+# HELP haproxy_server_weight Current weight of the server.
+# TYPE haproxy_server_weight gauge
+haproxy_server_weight{backend="test",server="127.0.0.1:8080"} 1
+# HELP haproxy_up Was the last scrape of haproxy successful.
+# TYPE haproxy_up gauge
+haproxy_up 1

--- a/test/unix_domain_deadline.metrics
+++ b/test/unix_domain_deadline.metrics
@@ -1,0 +1,9 @@
+# HELP haproxy_exporter_csv_parse_failures Number of errors while parsing CSV.
+# TYPE haproxy_exporter_csv_parse_failures counter
+haproxy_exporter_csv_parse_failures 0
+# HELP haproxy_exporter_total_scrapes Current total HAProxy scrapes.
+# TYPE haproxy_exporter_total_scrapes counter
+haproxy_exporter_total_scrapes 1
+# HELP haproxy_up Was the last scrape of haproxy successful.
+# TYPE haproxy_up gauge
+haproxy_up 0

--- a/test/unix_domain_not_found.metrics
+++ b/test/unix_domain_not_found.metrics
@@ -1,0 +1,9 @@
+# HELP haproxy_exporter_csv_parse_failures Number of errors while parsing CSV.
+# TYPE haproxy_exporter_csv_parse_failures counter
+haproxy_exporter_csv_parse_failures 0
+# HELP haproxy_exporter_total_scrapes Current total HAProxy scrapes.
+# TYPE haproxy_exporter_total_scrapes counter
+haproxy_exporter_total_scrapes 1
+# HELP haproxy_up Was the last scrape of haproxy successful.
+# TYPE haproxy_up gauge
+haproxy_up 0

--- a/vendor/github.com/prometheus/client_golang/prometheus/testutil/testutil.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/testutil/testutil.go
@@ -1,0 +1,189 @@
+// Copyright 2018 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package testutil provides helpers to test code using the prometheus package
+// of client_golang.
+//
+// While writing unit tests to verify correct instrumentation of your code, it's
+// a common mistake to mostly test the instrumentation library instead of your
+// own code. Rather than verifying that a prometheus.Counter's value has changed
+// as expected or that it shows up in the exposition after registration, it is
+// in general more robust and more faithful to the concept of unit tests to use
+// mock implementations of the prometheus.Counter and prometheus.Registerer
+// interfaces that simply assert that the Add or Register methods have been
+// called with the expected arguments. However, this might be overkill in simple
+// scenarios. The ToFloat64 function is provided for simple inspection of a
+// single-value metric, but it has to be used with caution.
+//
+// End-to-end tests to verify all or larger parts of the metrics exposition can
+// be implemented with the CollectAndCompare or GatherAndCompare functions. The
+// most appropriate use is not so much testing instrumentation of your code, but
+// testing custom prometheus.Collector implementations and in particular whole
+// exporters, i.e. programs that retrieve telemetry data from a 3rd party source
+// and convert it into Prometheus metrics.
+package testutil
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+
+	"github.com/prometheus/common/expfmt"
+
+	dto "github.com/prometheus/client_model/go"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/internal"
+)
+
+// ToFloat64 collects all Metrics from the provided Collector. It expects that
+// this results in exactly one Metric being collected, which must be a Gauge,
+// Counter, or Untyped. In all other cases, ToFloat64 panics. ToFloat64 returns
+// the value of the collected Metric.
+//
+// The Collector provided is typically a simple instance of Gauge or Counter, or
+// – less commonly – a GaugeVec or CounterVec with exactly one element. But any
+// Collector fulfilling the prerequisites described above will do.
+//
+// Use this function with caution. It is computationally very expensive and thus
+// not suited at all to read values from Metrics in regular code. This is really
+// only for testing purposes, and even for testing, other approaches are often
+// more appropriate (see this package's documentation).
+//
+// A clear anti-pattern would be to use a metric type from the prometheus
+// package to track values that are also needed for something else than the
+// exposition of Prometheus metrics. For example, you would like to track the
+// number of items in a queue because your code should reject queuing further
+// items if a certain limit is reached. It is tempting to track the number of
+// items in a prometheus.Gauge, as it is then easily available as a metric for
+// exposition, too. However, then you would need to call ToFloat64 in your
+// regular code, potentially quite often. The recommended way is to track the
+// number of items conventionally (in the way you would have done it without
+// considering Prometheus metrics) and then expose the number with a
+// prometheus.GaugeFunc.
+func ToFloat64(c prometheus.Collector) float64 {
+	var (
+		m      prometheus.Metric
+		mCount int
+		mChan  = make(chan prometheus.Metric)
+		done   = make(chan struct{})
+	)
+
+	go func() {
+		for m = range mChan {
+			mCount++
+		}
+		close(done)
+	}()
+
+	c.Collect(mChan)
+	close(mChan)
+	<-done
+
+	if mCount != 1 {
+		panic(fmt.Errorf("collected %d metrics instead of exactly 1", mCount))
+	}
+
+	pb := &dto.Metric{}
+	m.Write(pb)
+	if pb.Gauge != nil {
+		return pb.Gauge.GetValue()
+	}
+	if pb.Counter != nil {
+		return pb.Counter.GetValue()
+	}
+	if pb.Untyped != nil {
+		return pb.Untyped.GetValue()
+	}
+	panic(fmt.Errorf("collected a non-gauge/counter/untyped metric: %s", pb))
+}
+
+// CollectAndCompare registers the provided Collector with a newly created
+// pedantic Registry. It then does the same as GatherAndCompare, gathering the
+// metrics from the pedantic Registry.
+func CollectAndCompare(c prometheus.Collector, expected io.Reader, metricNames ...string) error {
+	reg := prometheus.NewPedanticRegistry()
+	if err := reg.Register(c); err != nil {
+		return fmt.Errorf("registering collector failed: %s", err)
+	}
+	return GatherAndCompare(reg, expected, metricNames...)
+}
+
+// GatherAndCompare gathers all metrics from the provided Gatherer and compares
+// it to an expected output read from the provided Reader in the Prometheus text
+// exposition format. If any metricNames are provided, only metrics with those
+// names are compared.
+func GatherAndCompare(g prometheus.Gatherer, expected io.Reader, metricNames ...string) error {
+	got, err := g.Gather()
+	if err != nil {
+		return fmt.Errorf("gathering metrics failed: %s", err)
+	}
+	if metricNames != nil {
+		got = filterMetrics(got, metricNames)
+	}
+	var tp expfmt.TextParser
+	wantRaw, err := tp.TextToMetricFamilies(expected)
+	if err != nil {
+		return fmt.Errorf("parsing expected metrics failed: %s", err)
+	}
+	want := internal.NormalizeMetricFamilies(wantRaw)
+
+	return compare(got, want)
+}
+
+// compare encodes both provided slices of metric families into the text format,
+// compares their string message, and returns an error if they do not match.
+// The error contains the encoded text of both the desired and the actual
+// result.
+func compare(got, want []*dto.MetricFamily) error {
+	var gotBuf, wantBuf bytes.Buffer
+	enc := expfmt.NewEncoder(&gotBuf, expfmt.FmtText)
+	for _, mf := range got {
+		if err := enc.Encode(mf); err != nil {
+			return fmt.Errorf("encoding gathered metrics failed: %s", err)
+		}
+	}
+	enc = expfmt.NewEncoder(&wantBuf, expfmt.FmtText)
+	for _, mf := range want {
+		if err := enc.Encode(mf); err != nil {
+			return fmt.Errorf("encoding expected metrics failed: %s", err)
+		}
+	}
+
+	if wantBuf.String() != gotBuf.String() {
+		return fmt.Errorf(`
+metric output does not match expectation; want:
+
+%s
+
+got:
+
+%s
+`, wantBuf.String(), gotBuf.String())
+
+	}
+	return nil
+}
+
+func filterMetrics(metrics []*dto.MetricFamily, names []string) []*dto.MetricFamily {
+	var filtered []*dto.MetricFamily
+	for _, m := range metrics {
+		for _, name := range names {
+			if m.GetName() == name {
+				filtered = append(filtered, m)
+				break
+			}
+		}
+	}
+	return filtered
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,6 +13,7 @@ github.com/matttproud/golang_protobuf_extensions/pbutil
 github.com/prometheus/client_golang/prometheus
 github.com/prometheus/client_golang/prometheus/promhttp
 github.com/prometheus/client_golang/prometheus/internal
+github.com/prometheus/client_golang/prometheus/testutil
 # github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910
 github.com/prometheus/client_model/go
 # github.com/prometheus/common v0.0.0-20181126121408-4724e9255275


### PR DESCRIPTION
This also required completely re-doing the tests using the excellent
CollectAndCompare() from the new client_golang, which uncovered a bug in
HAProxy exporter when scraping old HAProxy versions that did not have all CSV
fields (some metrics would be randomly missing in the output because we broke
out of a loop in a non-deterministic way).

Fixes #43

Signed-off-by: Julius Volz <julius.volz@gmail.com>