### PR TITLE
Add support for "show info"

### DIFF
--- a/haproxy_exporter_test.go
+++ b/haproxy_exporter_test.go
@@ -32,7 +32,10 @@ import (
 	"github.com/prometheus/client_golang/prometheus/testutil"
 )
 
-const testSocket = "/tmp/haproxyexportertest.sock"
+const (
+	testSocket = "/tmp/haproxyexportertest.sock"
+	testInfo   = "Release_date: test date\nVersion: test version\n"
+)
 
 type haproxy struct {
 	*httptest.Server
@@ -167,7 +170,7 @@ func TestNotFound(t *testing.T) {
 	expectMetrics(t, e, "not_found.metrics")
 }
 
-func newHaproxyUnix(file, statsPayload string) (io.Closer, error) {
+func newHaproxyUnix(file, statsPayload string, infoPayload string) (io.Closer, error) {
 	if err := os.Remove(file); err != nil && !os.IsNotExist(err) {
 		return nil, err
 	}
@@ -190,6 +193,9 @@ func newHaproxyUnix(file, statsPayload string) (io.Closer, error) {
 						return
 					}
 					switch l {
+					case "show info\n":
+						c.Write([]byte(infoPayload))
+						return
 					case "show stat\n":
 						c.Write([]byte(statsPayload))
 						return
@@ -209,7 +215,7 @@ func TestUnixDomain(t *testing.T) {
 		t.Skip("not on windows")
 		return
 	}
-	srv, err := newHaproxyUnix(testSocket, "test,127.0.0.1:8080,0,0,0,0,0,0,0,0,,0,,0,0,0,0,no check,1,1,0,0,,,0,,1,1,1,,0,,2,0,,0,,,,0,0,0,0,0,0,0,,,,0,0,,,,,,,,,,,\n")
+	srv, err := newHaproxyUnix(testSocket, "test,127.0.0.1:8080,0,0,0,0,0,0,0,0,,0,,0,0,0,0,no check,1,1,0,0,,,0,,1,1,1,,0,,2,0,,0,,,,0,0,0,0,0,0,0,,,,0,0,,,,,,,,,,,\n", testInfo)
 	if err != nil {
 		t.Fatalf("can't start test server: %v", err)
 	}

--- a/test/deadline.metrics
+++ b/test/deadline.metrics
@@ -4,6 +4,6 @@ haproxy_exporter_csv_parse_failures 0
 # HELP haproxy_exporter_total_scrapes Current total HAProxy scrapes.
 # TYPE haproxy_exporter_total_scrapes counter
 haproxy_exporter_total_scrapes 1
-# HELP haproxy_up Was the last scrape of haproxy successful.
+# HELP haproxy_up Was the last scrape of HAProxy successful.
 # TYPE haproxy_up gauge
 haproxy_up 0

--- a/test/invalid_config.metrics
+++ b/test/invalid_config.metrics
@@ -4,6 +4,6 @@ haproxy_exporter_csv_parse_failures 1
 # HELP haproxy_exporter_total_scrapes Current total HAProxy scrapes.
 # TYPE haproxy_exporter_total_scrapes counter
 haproxy_exporter_total_scrapes 1
-# HELP haproxy_up Was the last scrape of haproxy successful.
+# HELP haproxy_up Was the last scrape of HAProxy successful.
 # TYPE haproxy_up gauge
 haproxy_up 1

--- a/test/not_found.metrics
+++ b/test/not_found.metrics
@@ -4,6 +4,6 @@ haproxy_exporter_csv_parse_failures 0
 # HELP haproxy_exporter_total_scrapes Current total HAProxy scrapes.
 # TYPE haproxy_exporter_total_scrapes counter
 haproxy_exporter_total_scrapes 1
-# HELP haproxy_up Was the last scrape of haproxy successful.
+# HELP haproxy_up Was the last scrape of HAProxy successful.
 # TYPE haproxy_up gauge
 haproxy_up 0

--- a/test/older_haproxy_versions.metrics
+++ b/test/older_haproxy_versions.metrics
@@ -84,6 +84,6 @@ haproxy_server_up{backend="foo",server="foo-instance-0"} 1
 haproxy_server_weight{backend="foo",server="BACKEND"} 1
 haproxy_server_weight{backend="foo",server="FRONTEND"} 1
 haproxy_server_weight{backend="foo",server="foo-instance-0"} 1
-# HELP haproxy_up Was the last scrape of haproxy successful.
+# HELP haproxy_up Was the last scrape of HAProxy successful.
 # TYPE haproxy_up gauge
 haproxy_up 1

--- a/test/server_broken_csv.metrics
+++ b/test/server_broken_csv.metrics
@@ -109,6 +109,6 @@ haproxy_server_up{backend="foo",server="foo-instance-0"} 1
 haproxy_server_weight{backend="foo",server="BACKEND"} 1
 haproxy_server_weight{backend="foo",server="FRONTEND"} 1
 haproxy_server_weight{backend="foo",server="foo-instance-0"} 1
-# HELP haproxy_up Was the last scrape of haproxy successful.
+# HELP haproxy_up Was the last scrape of HAProxy successful.
 # TYPE haproxy_up gauge
 haproxy_up 1

--- a/test/server_without_checks.metrics
+++ b/test/server_without_checks.metrics
@@ -75,6 +75,6 @@ haproxy_server_up{backend="test",server="127.0.0.1:8080"} 1
 # HELP haproxy_server_weight Current weight of the server.
 # TYPE haproxy_server_weight gauge
 haproxy_server_weight{backend="test",server="127.0.0.1:8080"} 1
-# HELP haproxy_up Was the last scrape of haproxy successful.
+# HELP haproxy_up Was the last scrape of HAProxy successful.
 # TYPE haproxy_up gauge
 haproxy_up 1

--- a/test/unix_domain.metrics
+++ b/test/unix_domain.metrics
@@ -75,6 +75,9 @@ haproxy_server_up{backend="test",server="127.0.0.1:8080"} 1
 # HELP haproxy_server_weight Current weight of the server.
 # TYPE haproxy_server_weight gauge
 haproxy_server_weight{backend="test",server="127.0.0.1:8080"} 1
-# HELP haproxy_up Was the last scrape of haproxy successful.
+# HELP haproxy_up Was the last scrape of HAProxy successful.
 # TYPE haproxy_up gauge
 haproxy_up 1
+# HELP haproxy_version_info HAProxy version info.
+# TYPE haproxy_version_info gauge
+haproxy_version_info{release_date="test date",version="test version"} 1

--- a/test/unix_domain_deadline.metrics
+++ b/test/unix_domain_deadline.metrics
@@ -4,6 +4,6 @@ haproxy_exporter_csv_parse_failures 0
 # HELP haproxy_exporter_total_scrapes Current total HAProxy scrapes.
 # TYPE haproxy_exporter_total_scrapes counter
 haproxy_exporter_total_scrapes 1
-# HELP haproxy_up Was the last scrape of haproxy successful.
+# HELP haproxy_up Was the last scrape of HAProxy successful.
 # TYPE haproxy_up gauge
 haproxy_up 0

--- a/test/unix_domain_not_found.metrics
+++ b/test/unix_domain_not_found.metrics
@@ -4,6 +4,6 @@ haproxy_exporter_csv_parse_failures 0
 # HELP haproxy_exporter_total_scrapes Current total HAProxy scrapes.
 # TYPE haproxy_exporter_total_scrapes counter
 haproxy_exporter_total_scrapes 1
-# HELP haproxy_up Was the last scrape of haproxy successful.
+# HELP haproxy_up Was the last scrape of HAProxy successful.
 # TYPE haproxy_up gauge
 haproxy_up 0


### PR DESCRIPTION
Add a new haproxy_version_info metric by running the "show info" command
on the UNIX socket.

This feature is not supported in HTTP mode. It will require some
refactoring of the HTTP stats method to handle this.

Signed-off-by: Ben Kochie <superq@gmail.com>