### PR TITLE
Add version flag

### DIFF
--- a/haproxy_exporter.go
+++ b/haproxy_exporter.go
@@ -563,6 +563,7 @@ func main() {
 
 	promlogConfig := &promlog.Config{}
 	flag.AddFlags(kingpin.CommandLine, promlogConfig)
+	kingpin.Version(version.Print("haproxy_exporter"))
 	kingpin.HelpFlag.Short('h')
 	kingpin.Parse()
 	logger := promlog.New(promlogConfig)


### PR DESCRIPTION
To properly check which version of the exporter had been installed from
a binary it helps a lot to support the --version flag as the other
exporters. It's just a one-line fix to print the version information on
the CLI.

```
$ ./haproxy_exporter --version
haproxy_exporter, version 0.11.0 (branch: master, revision: 166e9ba36bfcd70f433a5665064c08ba0b9937df)
  build user:       tboerger@osiris.local
  build date:       20200721-09
```
