### PR TITLE
Added missing _time_average_seconds per server metrics

### DIFF
--- a/haproxy_exporter.go
+++ b/haproxy_exporter.go
@@ -162,6 +162,10 @@ var (
 		44: newServerMetric("http_responses_total", "Total of HTTP responses.", prometheus.CounterValue, prometheus.Labels{"code": "other"}),
 		49: newServerMetric("client_aborts_total", "Total number of data transfers aborted by the client.", prometheus.CounterValue, nil),
 		50: newServerMetric("server_aborts_total", "Total number of data transfers aborted by the server.", prometheus.CounterValue, nil),
+		58: newServerMetric("http_queue_time_average_seconds", "Avg. HTTP queue time for last 1024 successful connections.", prometheus.GaugeValue, nil),
+		59: newServerMetric("http_connect_time_average_seconds", "Avg. HTTP connect time for last 1024 successful connections.", prometheus.GaugeValue, nil),
+		60: newServerMetric("http_response_time_average_seconds", "Avg. HTTP response time for last 1024 successful connections.", prometheus.GaugeValue, nil),
+		61: newServerMetric("http_total_time_average_seconds", "Avg. HTTP total time for last 1024 successful connections.", prometheus.GaugeValue, nil),
 	}
 
 	frontendMetrics = metrics{


### PR DESCRIPTION
haproxy_server_http_connect_time_average_seconds
haproxy_server_http_total_time_average_seconds
haproxy_server_http_queue_time_average_seconds
haproxy_server_http_response_time_average_seconds

Added the above metrics, these are reported by haproxy, but exporter doesn't collect them. They're important identifying outliers at a quick glance in larger pools.
 
