### PR TITLE
Fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 ARG ARCH="amd64"
 ARG OS="linux"
-FROM        quay.io/prometheus/busybox:latest
+FROM quay.io/prometheus/busybox-${OS}-${ARCH}:latest
 LABEL maintainer="The Prometheus Authors <prometheus-developers@googlegroups.com>"
 
 ARG ARCH="amd64"
 ARG OS="linux"
 COPY .build/${OS}-${ARCH}/haproxy_exporter /bin/haproxy_exporter
 
-USER nobody
-ENTRYPOINT ["/bin/haproxy_exporter"]
-EXPOSE     9101
+EXPOSE      9101
+USER        nobody
+ENTRYPOINT  [ "/bin/haproxy_exporter" ]


### PR DESCRIPTION
Use the correct busybox arch image so that docker-manifest picks up the
correct arch.

Fixes: https://github.com/prometheus/haproxy_exporter/issues/209

Signed-off-by: Ben Kochie <superq@gmail.com>