### PR TITLE
Add idle metric

### DIFF
--- a/haproxy_exporter.go
+++ b/haproxy_exporter.go
@@ -232,8 +232,9 @@ var (
 		61: newBackendMetric("http_total_time_average_seconds", "Avg. HTTP total time for last 1024 successful connections.", prometheus.GaugeValue, nil),
 	}
 
-	haproxyInfo = prometheus.NewDesc(prometheus.BuildFQName(namespace, "version", "info"), "HAProxy version info.", []string{"release_date", "version"}, nil)
-	haproxyUp   = prometheus.NewDesc(prometheus.BuildFQName(namespace, "", "up"), "Was the last scrape of HAProxy successful.", nil, nil)
+	haproxyInfo    = prometheus.NewDesc(prometheus.BuildFQName(namespace, "version", "info"), "HAProxy version info.", []string{"release_date", "version"}, nil)
+	haproxyUp      = prometheus.NewDesc(prometheus.BuildFQName(namespace, "", "up"), "Was the last scrape of HAProxy successful.", nil, nil)
+	haproxyIdlePct = prometheus.NewDesc(prometheus.BuildFQName(namespace, "idle", "percent"), "Time spent waiting for events instead of processing them.", nil, nil)
 )
 
 // Exporter collects HAProxy stats from the given URI and exports them using
@@ -314,6 +315,7 @@ func (e *Exporter) Describe(ch chan<- *prometheus.Desc) {
 	}
 	ch <- haproxyInfo
 	ch <- haproxyUp
+	ch <- haproxyIdlePct
 	ch <- e.totalScrapes.Desc()
 	ch <- e.csvParseFailures.Desc()
 }
@@ -391,6 +393,9 @@ func (e *Exporter) scrape(ch chan<- prometheus.Metric) (up float64) {
 			level.Debug(e.logger).Log("msg", "Failed parsing show info", "err", err)
 		} else {
 			ch <- prometheus.MustNewConstMetric(haproxyInfo, prometheus.GaugeValue, 1, info.ReleaseDate, info.Version)
+			if info.IdlePct != -1 {
+				ch <- prometheus.MustNewConstMetric(haproxyIdlePct, prometheus.GaugeValue, info.IdlePct)
+			}
 		}
 	}
 
@@ -429,10 +434,13 @@ loop:
 type versionInfo struct {
 	ReleaseDate string
 	Version     string
+	IdlePct     float64
 }
 
 func (e *Exporter) parseInfo(i io.Reader) (versionInfo, error) {
 	var version, releaseDate string
+	// A value of -1 is used to indicate it's unset
+	var idlePct float64 = -1
 	s := bufio.NewScanner(i)
 	for s.Scan() {
 		line := s.Text()
@@ -446,9 +454,14 @@ func (e *Exporter) parseInfo(i io.Reader) (versionInfo, error) {
 			releaseDate = field[1]
 		case "Version":
 			version = field[1]
+		case "Idle_pct":
+			i, err := strconv.ParseFloat(field[1], 10)
+			if err == nil && i >= 0 && i <= 100 {
+				idlePct = i
+			}
 		}
 	}
-	return versionInfo{ReleaseDate: releaseDate, Version: version}, s.Err()
+	return versionInfo{ReleaseDate: releaseDate, Version: version, IdlePct: idlePct}, s.Err()
 }
 
 func (e *Exporter) parseRow(csvRow []string, ch chan<- prometheus.Metric) {

--- a/haproxy_exporter.go
+++ b/haproxy_exporter.go
@@ -439,7 +439,7 @@ type versionInfo struct {
 
 func (e *Exporter) parseInfo(i io.Reader) (versionInfo, error) {
 	var version, releaseDate string
-	// A value of -1 is used to indicate it's unset
+	// idlePct value of -1 is used to indicate it's unset
 	var idlePct float64 = -1
 	s := bufio.NewScanner(i)
 	for s.Scan() {

--- a/haproxy_exporter_test.go
+++ b/haproxy_exporter_test.go
@@ -34,7 +34,7 @@ import (
 
 const (
 	testSocket = "/tmp/haproxyexportertest.sock"
-	testInfo   = "Release_date: test date\nVersion: test version\n"
+	testInfo   = "Release_date: test date\nVersion: test version\nIdle_pct: 100\n"
 )
 
 type haproxy struct {

--- a/test/unix_domain.metrics
+++ b/test/unix_domain.metrics
@@ -81,3 +81,6 @@ haproxy_up 1
 # HELP haproxy_version_info HAProxy version info.
 # TYPE haproxy_version_info gauge
 haproxy_version_info{release_date="test date",version="test version"} 1
+# HELP haproxy_idle_percent Time spent waiting for events instead of processing them.
+# TYPE haproxy_idle_percent gauge
+haproxy_idle_percent 100


### PR DESCRIPTION
HAProxy docs mention that the [Idle_pct](http://cbonte.github.io/haproxy-dconv/2.5/management.html#7) metric indicates how busy the event loop is; The closer to zero the value, the closer HAProxy is to its processing capacity.

This seems like a useful metric for capacity planning, so this PR is to include it metrics when scraping HAProxy via unix sockets.
