### PR TITLE
Support tcp scheme

### DIFF
--- a/haproxy_exporter.go
+++ b/haproxy_exporter.go
@@ -264,8 +264,11 @@ func NewExporter(uri string, sslVerify, proxyFromEnv bool, selectedServerMetrics
 	case "http", "https", "file":
 		fetchStat = fetchHTTP(uri, sslVerify, proxyFromEnv, timeout)
 	case "unix":
-		fetchInfo = fetchUnix(u, showInfoCmd, timeout)
-		fetchStat = fetchUnix(u, showStatCmd, timeout)
+		fetchInfo = fetchUnix("unix", u.Path, showInfoCmd, timeout)
+		fetchStat = fetchUnix("unix", u.Path, showStatCmd, timeout)
+	case "tcp":
+		fetchInfo = fetchUnix("tcp", u.Host, showInfoCmd, timeout)
+		fetchStat = fetchUnix("tcp", u.Host, showStatCmd, timeout)
 	default:
 		return nil, fmt.Errorf("unsupported scheme: %q", u.Scheme)
 	}
@@ -354,9 +357,9 @@ func fetchHTTP(uri string, sslVerify, proxyFromEnv bool, timeout time.Duration) 
 	}
 }
 
-func fetchUnix(u *url.URL, cmd string, timeout time.Duration) func() (io.ReadCloser, error) {
+func fetchUnix(scheme, address, cmd string, timeout time.Duration) func() (io.ReadCloser, error) {
 	return func() (io.ReadCloser, error) {
-		f, err := net.DialTimeout("unix", u.Path, timeout)
+		f, err := net.DialTimeout(scheme, address, timeout)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Hello,

A very simple PR to add support for `tcp` scheme. It is identical with `unix` (same haproxy API endpoint, not the same as http UI) except you access it by tcp address. We use it by default for a long time.

Here is an example how to enable it this way:
```
global
    stats socket ipv4@127.0.0.1:9899 level admin
```
Thanks!