### PR TITLE
Remove ioutil

### DIFF
--- a/haproxy_exporter_test.go
+++ b/haproxy_exporter_test.go
@@ -16,7 +16,6 @@ package main
 import (
 	"bufio"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -344,7 +343,7 @@ func TestFilterServerMetrics(t *testing.T) {
 }
 
 func BenchmarkExtract(b *testing.B) {
-	config, err := ioutil.ReadFile("test/haproxy.csv")
+	config, err := os.ReadFile("test/haproxy.csv")
 	if err != nil {
 		b.Fatalf("could not read config file: %v", err.Error())
 	}


### PR DESCRIPTION
`ioutil` is deprecated from go1.16 (ref: https://go.dev/doc/go1.16#ioutil).
So removed them.

Signed-off-by: inosato <si17_21@yahoo.co.jp>