### PR TITLE
Document passing arguments through a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,14 @@ scrape URL:
 haproxy_exporter  --haproxy.scrape-uri="http://user:pass@haproxy.example.com/haproxy?stats;csv"
 ```
 
+Alternatively, provide the password through a file, so that it does not appear in the process
+table or in the output of the ```/debug/pprof/cmdline``` profiling service:
+
+```bash
+echo '--haproxy.scrape-uri=http://user:pass@haproxy.example.com/haproxy?stats;csv' > args
+haproxy_exporter @args
+```
+
 You can also scrape HTTPS URLs. Certificate validation is enabled by default, but
 you can disable it using the `--no-haproxy.ssl-verify` flag:
 


### PR DESCRIPTION
Providing basic auth parameters through the command line
is insecure and raised some eyebrows in
https://github.com/prometheus/haproxy_exporter/issues/102

Kingpin in
https://github.com/alecthomas/kingpin#reading-arguments-from-a-file
provides a way to specify parameters through a file so we can
document that too.

In addition to prevent the leak of the password in the process table
(making any user currently logged on the machine able to read the
password), this also prevent a remote user to read the credentials
through the pprof cmdline service.

Signed-off-by: François Rigault <frigo@amadeus.com>