### PR TITLE
Use same name for idle percent metric as upstream

### DIFF
--- a/haproxy_exporter.go
+++ b/haproxy_exporter.go
@@ -234,7 +234,7 @@ var (
 
 	haproxyInfo    = prometheus.NewDesc(prometheus.BuildFQName(namespace, "version", "info"), "HAProxy version info.", []string{"release_date", "version"}, nil)
 	haproxyUp      = prometheus.NewDesc(prometheus.BuildFQName(namespace, "", "up"), "Was the last scrape of HAProxy successful.", nil, nil)
-	haproxyIdlePct = prometheus.NewDesc(prometheus.BuildFQName(namespace, "idle", "percent"), "Time spent waiting for events instead of processing them.", nil, nil)
+	haproxyIdlePct = prometheus.NewDesc(prometheus.BuildFQName(namespace, "process_idle_time", "percent"), "Time spent waiting for events instead of processing them.", nil, nil)
 )
 
 // Exporter collects HAProxy stats from the given URI and exports them using

--- a/haproxy_exporter.go
+++ b/haproxy_exporter.go
@@ -461,7 +461,7 @@ func (e *Exporter) parseInfo(i io.Reader) (versionInfo, error) {
 		case "Version":
 			version = field[1]
 		case "Idle_pct":
-			i, err := strconv.ParseFloat(field[1], 10)
+			i, err := strconv.ParseFloat(field[1], 64)
 			if err == nil && i >= 0 && i <= 100 {
 				idlePct = i
 			}

--- a/test/unix_domain.metrics
+++ b/test/unix_domain.metrics
@@ -81,6 +81,6 @@ haproxy_up 1
 # HELP haproxy_version_info HAProxy version info.
 # TYPE haproxy_version_info gauge
 haproxy_version_info{release_date="test date",version="test version"} 1
-# HELP haproxy_idle_percent Time spent waiting for events instead of processing them.
-# TYPE haproxy_idle_percent gauge
-haproxy_idle_percent 100
+# HELP haproxy_process_idle_time_percent Time spent waiting for events instead of processing them.
+# TYPE haproxy_process_idle_time_percent gauge
+haproxy_process_idle_time_percent 100


### PR DESCRIPTION
The official HAProxy exporter plugin uses
`haproxy_process_idle_time_percent`, let's be consistent with that.

Follow-up for #236.

Signed-off-by: Matthias Rampke <matthias@prometheus.io>