### PR TITLE
Remove unnecessary TrailingComma

### DIFF
--- a/haproxy_exporter.go
+++ b/haproxy_exporter.go
@@ -413,7 +413,6 @@ func (e *Exporter) scrape(ch chan<- prometheus.Metric) (up float64) {
 	defer body.Close()
 
 	reader := csv.NewReader(body)
-	reader.TrailingComma = true
 	reader.Comment = '#'
 
 loop:


### PR DESCRIPTION
As of Go 1.2(!) this is always the case. Silences a linter warning.